### PR TITLE
Fix parseTemplate() true and false values.

### DIFF
--- a/example/aes.php
+++ b/example/aes.php
@@ -11,8 +11,10 @@ $session->login(Pkcs11\CKU_USER,'123456');
 
 $key = $session->generateKey(Pkcs11\CKM_AES_KEY_GEN, [
 	Pkcs11\CKA_CLASS => Pkcs11\CKO_SECRET_KEY,
-	Pkcs11\CKA_TOKEN => true,
+	Pkcs11\CKA_TOKEN => false,
 	Pkcs11\CKA_SENSITIVE => true,
+	Pkcs11\CKA_ENCRYPT => true,
+	Pkcs11\CKA_DECRYPT => true,
 	Pkcs11\CKA_VALUE_LEN => 32,
 	Pkcs11\CKA_KEY_TYPE => Pkcs11\CKK_AES,
 	Pkcs11\CKA_LABEL => "Test AES",

--- a/pkcs11.c
+++ b/pkcs11.c
@@ -161,8 +161,8 @@ void parseTemplate(HashTable **template, CK_ATTRIBUTE_PTR *templateObj, int *tem
     *templateItemCount = zend_hash_num_elements(*template);
     *templateObj = ecalloc(*templateItemCount, sizeof(CK_ATTRIBUTE));
     unsigned int i = 0;
-    CK_BBOOL btrue = CK_TRUE;
-    CK_BBOOL bfalse = CK_FALSE;
+    static CK_BBOOL btrue = CK_TRUE;
+    static CK_BBOOL bfalse = CK_FALSE;
     ZEND_HASH_FOREACH_NUM_KEY_VAL(*template, templateValueKey, templateValue)
         if (Z_TYPE_P(templateValue) == IS_LONG) {
             (*templateObj)[i] = (CK_ATTRIBUTE){templateValueKey, &(Z_LVAL_P(templateValue)), sizeof(CK_ULONG)};


### PR DESCRIPTION
For template values true and false, parseTemplate() was populating the
template with local values that went out of scope when it returned, so the
template contained garbage by the time it was used.  Also allowing encrypt
and decrypt in the AES example, which now works with a Luna HSM.