### PR TITLE
Testv2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,11 +27,11 @@ missing
 mkinstalldirs
 modules
 run-tests.php
-tests/*/*.diff
-tests/*/*.out
-tests/*/*.php
-tests/*/*.exp
-tests/*/*.log
-tests/*/*.sh
+tests/*.diff
+tests/*.out
+tests/*.php
+tests/*.exp
+tests/*.log
+tests/*.sh
 
 example/vendor

--- a/pkcs11module.c
+++ b/pkcs11module.c
@@ -566,9 +566,10 @@ PHP_METHOD(Module, C_GetMechanismList) {
 }
 
 
-CK_RV php_C_GetMechanismInfo(pkcs11_object *objval, CK_ULONG slotId, CK_ULONG mechanismId, zval *retval) {
+CK_RV php_C_GetMechanismInfo(pkcs11_object *objval, CK_SLOT_ID slotId, CK_MECHANISM_TYPE mechanismId, zval *retval) {
 
-    CK_MECHANISM_INFO mechanismInfo;
+    CK_MECHANISM_INFO mechanismInfo = {};
+
     CK_RV rv = objval->functionList->C_GetMechanismInfo(slotId, mechanismId, &mechanismInfo);
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to get mechanism info");
@@ -576,8 +577,9 @@ CK_RV php_C_GetMechanismInfo(pkcs11_object *objval, CK_ULONG slotId, CK_ULONG me
     }
 
     array_init(retval);
-    add_assoc_long(retval, "min_key_size", mechanismInfo.ulMinKeySize);
-    add_assoc_long(retval, "max_key_size", mechanismInfo.ulMaxKeySize);
+    add_assoc_long(retval, "ulMinKeySize", mechanismInfo.ulMinKeySize);
+    add_assoc_long(retval, "ulMaxKeySize", mechanismInfo.ulMaxKeySize);
+    add_assoc_long(retval, "flags", mechanismInfo.ulMaxKeySize);
 
     return rv;
 }

--- a/pkcs11module.c
+++ b/pkcs11module.c
@@ -492,7 +492,7 @@ PHP_METHOD(Module, C_GetTokenInfo) {
 }
 
 
-CK_RV php_C_GetMechanismList(pkcs11_object *objval, CK_ULONG slotId, zval *retval) {
+CK_RV php_C_GetMechanismList(pkcs11_object *objval, CK_SLOT_ID slotId, zval *retval) {
 
     CK_RV rv;
 
@@ -511,7 +511,7 @@ CK_RV php_C_GetMechanismList(pkcs11_object *objval, CK_ULONG slotId, zval *retva
         return rv;
     }
 
-    uint i;
+    CK_SLOT_ID i;
     array_init(retval);
     for (i=0; i<ulMechanismCount; i++) {
         add_next_index_long(retval, pMechanismList[i]);

--- a/tests/0020-oasis-C_GetSlotList.phpt
+++ b/tests/0020-oasis-C_GetSlotList.phpt
@@ -1,5 +1,5 @@
 --TEST--
-OASIS C_GetInfo() Basic test
+OASIS C_GetSlotList() Basic test
 --SKIPIF--
 <?php
 if (!extension_loaded('pkcs11')) {

--- a/tests/0030-oasis-C_GetSlotInfo.phpt
+++ b/tests/0030-oasis-C_GetSlotInfo.phpt
@@ -1,5 +1,5 @@
 --TEST--
-OASIS C_GetInfo() Basic test
+OASIS GetSlotInfo() Basic test
 --SKIPIF--
 <?php
 if (!extension_loaded('pkcs11')) {

--- a/tests/0040-oasis-C_GetTokenInfo.phpt
+++ b/tests/0040-oasis-C_GetTokenInfo.phpt
@@ -1,0 +1,30 @@
+--TEST--
+OASIS C_GetTokenInfo() Basic test
+--SKIPIF--
+<?php
+if (!extension_loaded('pkcs11')) {
+  echo 'skip';
+}
+
+if (getenv('PHP11_MODULE') === false) {
+  echo 'skip';
+}
+?>
+--FILE--
+<?php declare(strict_types=1);
+
+$modulePath = getenv('PHP11_MODULE');
+$module = new Pkcs11\Module($modulePath);
+
+$rv = $module->C_GetSlotList(true, $slotList);
+var_dump($rv);
+
+$rv = $module->C_GetTokenInfo($slotList[0], $tokenInfo);
+var_dump($rv);
+var_dump(sizeof($tokenInfo, COUNT_RECURSIVE));
+
+?>
+--EXPECTF--
+int(0)
+int(0)
+int(21)

--- a/tests/0050-oasis-C_GetMechanismList.phpt
+++ b/tests/0050-oasis-C_GetMechanismList.phpt
@@ -1,0 +1,46 @@
+--TEST--
+OASIS C_GetMechanismList(), C_GetMechanismInfo() Basic test
+--SKIPIF--
+<?php
+if (!extension_loaded('pkcs11')) {
+  echo 'skip';
+}
+
+if (getenv('PHP11_MODULE') === false) {
+  echo 'skip';
+}
+?>
+--FILE--
+<?php declare(strict_types=1);
+
+/* build a list of mechanism that the card may support */
+$c = get_defined_constants(TRUE)['pkcs11'];
+foreach($c as $k => $v) {
+  if (strpos($k, 'CKM_') === FALSE)
+    continue;
+  if ($k === 'Pkcs11\CKM_VENDOR_DEFINED')
+    continue;
+  $ckm[$v] = $k;
+}
+
+$modulePath = getenv('PHP11_MODULE');
+$module = new Pkcs11\Module($modulePath);
+
+$rv = $module->C_GetSlotList(true, $s);
+var_dump($rv);
+
+$rv = $module->C_GetMechanismList($s[0], $alg);
+var_dump($rv);
+printf("PKCS11 supported algorithms:".PHP_EOL);
+foreach($alg as $k => $t) {
+  printf("%s".PHP_EOL, $ckm[$t]);
+  $rv = $module->C_GetMechanismInfo($s[0], $t, $mechanismInfo);
+  print_r($mechanismInfo);
+}
+
+?>
+--EXPECTF--
+int(0)
+int(0)
+PKCS11 supported algorithms:
+%A


### PR DESCRIPTION
some more tests including some minor fixes of C_GetMechanism{List|info}()

It passes all the non regression tests:
PASS Check if pkcs11 is loaded [tests/0001-checkmodule.phpt] 
PASS OASIS C_GetInfo() Basic test [tests/0010-oasis_C_GetInfo.phpt] 
PASS OASIS C_GetSlotList() Basic test [tests/0020-oasis-C_GetSlotList.phpt] 
PASS OASIS GetSlotInfo() Basic test [tests/0030-oasis-C_GetSlotInfo.phpt] 
PASS OASIS C_GetTokenInfo() Basic test [tests/0040-oasis-C_GetTokenInfo.phpt] 
PASS OASIS C_GetMechanismList(), C_GetMechanismInfo() Basic test [tests/0050-oasis-C_GetMechanismList.phpt] 