### PR TITLE
Zero Parameters: be explicit

### DIFF
--- a/pkcs11module.c
+++ b/pkcs11module.c
@@ -182,6 +182,8 @@ CK_RV php_C_GetInfo(pkcs11_object *objval, zval *retval) {
 PHP_METHOD(Module, getInfo) {
     pkcs11_object *objval = Z_PKCS11_P(ZEND_THIS);
 
+    ZEND_PARSE_PARAMETERS_NONE();
+
     if (!objval->initialised) {
         zend_throw_exception(zend_ce_exception, "Uninitialised PKCS11 module", 0);
         return;
@@ -250,6 +252,8 @@ PHP_METHOD(Module, getSlots) {
     CK_SLOT_ID_PTR pSlotList;
     CK_SLOT_INFO slotInfo;
 
+    ZEND_PARSE_PARAMETERS_NONE();
+
     pkcs11_object *objval = Z_PKCS11_P(ZEND_THIS);
 
     if (!objval->initialised) {
@@ -289,6 +293,8 @@ PHP_METHOD(Module, getSlots) {
 }
 
 PHP_METHOD(Module, getSlotList) {
+
+    ZEND_PARSE_PARAMETERS_NONE();
 
     pkcs11_object *objval = Z_PKCS11_P(ZEND_THIS);
 

--- a/pkcs11session.c
+++ b/pkcs11session.c
@@ -84,6 +84,8 @@ PHP_METHOD(Session, getInfo) {
     CK_RV rv;
     CK_SESSION_INFO sessionInfo;
 
+    ZEND_PARSE_PARAMETERS_NONE();
+
     pkcs11_session_object *objval = Z_PKCS11_SESSION_P(ZEND_THIS);
     rv = objval->pkcs11->functionList->C_GetSessionInfo(objval->session, &sessionInfo);
 
@@ -121,6 +123,8 @@ PHP_METHOD(Session, login) {
 PHP_METHOD(Session, logout) {
 
     CK_RV rv;
+
+    ZEND_PARSE_PARAMETERS_NONE();
 
     pkcs11_session_object *objval = Z_PKCS11_SESSION_P(ZEND_THIS);
     rv = objval->pkcs11->functionList->C_Logout(objval->session);


### PR DESCRIPTION
Since PHP 7.x, we can enforce that there is no parameter to be parsed.