### PR TITLE
Fix test: heurisitc on C_GetTokenInfo()

### DIFF
--- a/tests/0040-oasis-C_GetTokenInfo.phpt
+++ b/tests/0040-oasis-C_GetTokenInfo.phpt
@@ -27,4 +27,4 @@ var_dump(sizeof($tokenInfo, COUNT_RECURSIVE));
 --EXPECTF--
 int(0)
 int(0)
-int(21)
+int(22)


### PR DESCRIPTION
There 22 entries from the associative array.