### PR TITLE
Sessionv5

### DIFF
--- a/pkcs11int.h
+++ b/pkcs11int.h
@@ -221,4 +221,6 @@ extern int call_obj_func(zend_object *object, char *function_name, zval *retval_
 
 CK_RV php_C_GenerateRandom(const pkcs11_session_object * const objval, zend_long php_RandomLen, zval *retval);
 CK_RV php_C_SeedRandom(const pkcs11_session_object * const objval, zend_string *php_pSeed, zval *retval);
+extern CK_RV php_C_GetSessionInfo(const pkcs11_session_object * const objval, zval *retval);
+
 #endif

--- a/pkcs11int.h
+++ b/pkcs11int.h
@@ -220,4 +220,5 @@ extern void getObjectClass(pkcs11_session_object *session, CK_OBJECT_HANDLE_PTR 
 extern int call_obj_func(zend_object *object, char *function_name, zval *retval_ptr, uint32_t param_count, zval params[]);
 
 CK_RV php_C_GenerateRandom(const pkcs11_session_object * const objval, zend_long php_RandomLen, zval *retval);
+CK_RV php_C_SeedRandom(const pkcs11_session_object * const objval, zend_string *php_pSeed, zval *retval);
 #endif

--- a/pkcs11int.h
+++ b/pkcs11int.h
@@ -219,4 +219,5 @@ extern void freeTemplate(CK_ATTRIBUTE_PTR templateObj);
 extern void getObjectClass(pkcs11_session_object *session, CK_OBJECT_HANDLE_PTR hObject, CK_ULONG_PTR classId);
 extern int call_obj_func(zend_object *object, char *function_name, zval *retval_ptr, uint32_t param_count, zval params[]);
 
+CK_RV php_C_GenerateRandom(const pkcs11_session_object * const objval, zend_long php_RandomLen, zval *retval);
 #endif

--- a/pkcs11module.c
+++ b/pkcs11module.c
@@ -846,6 +846,29 @@ PHP_METHOD(Module, C_GenerateRandom) {
     RETURN_LONG(rv);
 }
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_C_SeedRandom, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, session, IS_OBJECT, 0)
+    ZEND_ARG_TYPE_INFO(0, Seed, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+PHP_METHOD(Module, C_SeedRandom) {
+    CK_RV rv;
+
+    zval *php_session;
+    zend_string *php_pSeed = NULL;
+    zval retval;
+
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_OBJECT_OF_CLASS(php_session, ce_Pkcs11_Session)
+        Z_PARAM_STR(php_pSeed)
+    ZEND_PARSE_PARAMETERS_END();
+
+    pkcs11_session_object *objval = Z_PKCS11_SESSION_P(php_session);
+    rv = php_C_SeedRandom(objval, php_pSeed, NULL);
+
+    RETURN_LONG(rv);
+}
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_C_Login, 0, 0, 3)
     ZEND_ARG_TYPE_INFO(0, session, IS_OBJECT, 0)
     ZEND_ARG_TYPE_INFO(0, loginType, IS_LONG, 0)
@@ -1349,6 +1372,7 @@ static zend_function_entry module_class_functions[] = {
     PHP_ME(Module, C_DigestFinal,             arginfo_C_DigestFinal,             ZEND_ACC_PUBLIC)
 
     PHP_ME(Module, C_GenerateRandom,          arginfo_C_GenerateRandom,          ZEND_ACC_PUBLIC)
+    PHP_ME(Module, C_SeedRandom,              arginfo_C_SeedRandom,              ZEND_ACC_PUBLIC)
     
     PHP_ME(Module, C_CreateObject,            arginfo_C_CreateObject,            ZEND_ACC_PUBLIC)
     PHP_ME(Module, C_FindObjects,             arginfo_C_FindObjects,             ZEND_ACC_PUBLIC)

--- a/pkcs11module.c
+++ b/pkcs11module.c
@@ -818,6 +818,34 @@ PHP_METHOD(Module, C_GetSessionInfo) {
     call_obj_func(&sessionobjval->std, "getInfo", return_value, 0, NULL);
 }
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_C_GenerateRandom, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, session, IS_OBJECT, 0)
+    ZEND_ARG_TYPE_INFO(0, RandomLen, IS_LONG, 0)
+    ZEND_ARG_INFO(1, pRandomData)
+ZEND_END_ARG_INFO()
+
+PHP_METHOD(Module, C_GenerateRandom) {
+    CK_RV rv;
+
+    zval *php_session;
+    zend_long php_RandomLen = 0;
+    zval *pRandomData;
+    zval retval;
+
+    ZEND_PARSE_PARAMETERS_START(3, 3)
+        Z_PARAM_OBJECT_OF_CLASS(php_session, ce_Pkcs11_Session)
+        Z_PARAM_LONG(php_RandomLen)
+        Z_PARAM_ZVAL(pRandomData)
+    ZEND_PARSE_PARAMETERS_END();
+
+    pkcs11_session_object *objval = Z_PKCS11_SESSION_P(php_session);
+    rv = php_C_GenerateRandom(objval, php_RandomLen, &retval);
+
+    ZEND_TRY_ASSIGN_REF_VALUE(pRandomData, &retval);
+
+    RETURN_LONG(rv);
+}
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_C_Login, 0, 0, 3)
     ZEND_ARG_TYPE_INFO(0, session, IS_OBJECT, 0)
     ZEND_ARG_TYPE_INFO(0, loginType, IS_LONG, 0)
@@ -1319,6 +1347,8 @@ static zend_function_entry module_class_functions[] = {
     PHP_ME(Module, C_DigestUpdate,            arginfo_C_DigestUpdate,            ZEND_ACC_PUBLIC)
     PHP_ME(Module, C_DigestKey,               arginfo_C_DigestKey,               ZEND_ACC_PUBLIC)
     PHP_ME(Module, C_DigestFinal,             arginfo_C_DigestFinal,             ZEND_ACC_PUBLIC)
+
+    PHP_ME(Module, C_GenerateRandom,          arginfo_C_GenerateRandom,          ZEND_ACC_PUBLIC)
     
     PHP_ME(Module, C_CreateObject,            arginfo_C_CreateObject,            ZEND_ACC_PUBLIC)
     PHP_ME(Module, C_FindObjects,             arginfo_C_FindObjects,             ZEND_ACC_PUBLIC)

--- a/pkcs11module.c
+++ b/pkcs11module.c
@@ -801,21 +801,28 @@ PHP_METHOD(Module, C_OpenSession) {
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_C_GetSessionInfo, 0, 0, 1)
     ZEND_ARG_TYPE_INFO(0, session, IS_OBJECT, 0)
+    ZEND_ARG_INFO(1, pInfo)
 ZEND_END_ARG_INFO()
 
 PHP_METHOD(Module, C_GetSessionInfo) {
     CK_RV rv;
 
     zval *session;
+    zval *pInfo;
+    zval retval;
 
-    ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_ZVAL(session)
+    ZEND_PARSE_PARAMETERS_START(2, 2)
+        Z_PARAM_OBJECT_OF_CLASS(session, ce_Pkcs11_Session)
+        Z_PARAM_ZVAL(pInfo)
     ZEND_PARSE_PARAMETERS_END();
 
-    pkcs11_object *objval = Z_PKCS11_P(ZEND_THIS);
     pkcs11_session_object *sessionobjval = Z_PKCS11_SESSION_P(session);
 
-    call_obj_func(&sessionobjval->std, "getInfo", return_value, 0, NULL);
+    rv = php_C_GetSessionInfo(sessionobjval, &retval);
+
+    ZEND_TRY_ASSIGN_REF_VALUE(pInfo, &retval);
+
+    RETURN_LONG(rv);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_C_GenerateRandom, 0, 0, 1)

--- a/pkcs11module.c
+++ b/pkcs11module.c
@@ -107,6 +107,7 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_C_OpenSession, 0, 0, 1)
     ZEND_ARG_INFO(1, hSession)
 ZEND_END_ARG_INFO()
 
+
 PHP_METHOD(Module, __construct) {
     char *module_path;
     size_t module_path_len;
@@ -799,6 +800,29 @@ PHP_METHOD(Module, C_OpenSession) {
     RETURN_LONG(rv);
 }
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo_C_CloseSession, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, session, IS_OBJECT, 0)
+ZEND_END_ARG_INFO()
+
+PHP_METHOD(Module, C_CloseSession) {
+    CK_RV rv;
+
+    zval *php_session;
+
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_OBJECT_OF_CLASS(php_session, ce_Pkcs11_Session)
+    ZEND_PARSE_PARAMETERS_END();
+
+    pkcs11_object *objval = Z_PKCS11_P(ZEND_THIS);
+    pkcs11_session_object *sessionobjval = Z_PKCS11_SESSION_P(php_session);
+
+    rv = sessionobjval->pkcs11->functionList->C_CloseSession(sessionobjval->session);
+    // TBC GC_DELREF(&objval->std); /* session is refering the pkcs11 module */
+    sessionobjval->session = 0;
+
+    RETURN_LONG(rv);
+}
+
 ZEND_BEGIN_ARG_INFO_EX(arginfo_C_GetSessionInfo, 0, 0, 1)
     ZEND_ARG_TYPE_INFO(0, session, IS_OBJECT, 0)
     ZEND_ARG_INFO(1, pInfo)
@@ -1380,6 +1404,7 @@ static zend_function_entry module_class_functions[] = {
     //PHP_MALIAS(Module, C_InitToken,        initToken,        arginfo_initToken,        ZEND_ACC_PUBLIC)
 
     PHP_ME(Module, C_OpenSession,             arginfo_C_OpenSession,             ZEND_ACC_PUBLIC)
+    PHP_ME(Module, C_CloseSession,            arginfo_C_CloseSession,            ZEND_ACC_PUBLIC)
     PHP_ME(Module, C_GetSessionInfo,          arginfo_C_GetSessionInfo,          ZEND_ACC_PUBLIC)
     PHP_ME(Module, C_Login,                   arginfo_C_Login,                   ZEND_ACC_PUBLIC)
     PHP_ME(Module, C_Logout,                  arginfo_C_Logout,                  ZEND_ACC_PUBLIC)

--- a/pkcs11module.c
+++ b/pkcs11module.c
@@ -886,21 +886,28 @@ PHP_METHOD(Module, C_Login) {
     CK_RV rv;
 
     zval *session;
-    zval *userType;
-    zval *pin;
+    zend_long userType;
+    zend_string *pin;
 
     ZEND_PARSE_PARAMETERS_START(3, 3)
-        Z_PARAM_ZVAL(session)
-        Z_PARAM_ZVAL(userType)
-        Z_PARAM_ZVAL(pin)
+        Z_PARAM_OBJECT_OF_CLASS(session, ce_Pkcs11_Session)
+        Z_PARAM_LONG(userType)
+        Z_PARAM_STR(pin)
     ZEND_PARSE_PARAMETERS_END();
 
     pkcs11_object *objval = Z_PKCS11_P(ZEND_THIS);
     pkcs11_session_object *sessionobjval = Z_PKCS11_SESSION_P(session);
 
+#ifdef notyet
+#error missing rv
     zval params[] = {*userType, *pin};
 
     call_obj_func(&sessionobjval->std, "login", return_value, 2, params);
+#endif
+
+    rv = sessionobjval->pkcs11->functionList->C_Login(sessionobjval->session, userType, ZSTR_VAL(pin), ZSTR_LEN(pin));
+
+    RETURN_LONG(rv);
 }
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_C_Logout, 0, 0, 1)
@@ -913,13 +920,20 @@ PHP_METHOD(Module, C_Logout) {
     zval *session;
 
     ZEND_PARSE_PARAMETERS_START(1, 1)
-        Z_PARAM_ZVAL(session)
+        Z_PARAM_OBJECT_OF_CLASS(session, ce_Pkcs11_Session)
     ZEND_PARSE_PARAMETERS_END();
 
     pkcs11_object *objval = Z_PKCS11_P(ZEND_THIS);
     pkcs11_session_object *sessionobjval = Z_PKCS11_SESSION_P(session);
 
+#ifdef notyet
+#error missing rv
     call_obj_func(&sessionobjval->std, "logout", return_value, 0, NULL);
+#endif
+
+    rv = sessionobjval->pkcs11->functionList->C_Logout(sessionobjval->session);
+
+    RETURN_LONG(rv);
 }
 
 

--- a/pkcs11session.c
+++ b/pkcs11session.c
@@ -86,6 +86,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_destroyObject, 0, 0, 1)
     ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo___debugInfo, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
 #if 0
 #error use C_OpenSession()
 extern zend_class_entry *ce_Pkcs11_Module;
@@ -652,6 +655,17 @@ PHP_METHOD(Session, destroyObject) {
     }
 }
 
+PHP_METHOD(Session, __debugInfo) {
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    pkcs11_session_object *objval = Z_PKCS11_SESSION_P(ZEND_THIS);
+
+    array_init(return_value);
+    add_assoc_long(return_value, "hSession", objval->session);
+    add_assoc_long(return_value, "slotID", objval->slotID);
+    /* TODO: add $module objval->std */
+}
+
 void pkcs11_session_shutdown(pkcs11_session_object *obj) {
     // called before the pkcs11_session_object is freed
     // TBC: is it called before pkcs11_shutdown() ? It has to.
@@ -677,6 +691,8 @@ static zend_function_entry session_class_functions[] = {
     PHP_ME(Session, initializeDigest, arginfo_initializeDigest, ZEND_ACC_PUBLIC)
     PHP_ME(Session, generateKey,      arginfo_generateKey,      ZEND_ACC_PUBLIC)
     PHP_ME(Session, generateKeyPair,  arginfo_generateKeyPair,  ZEND_ACC_PUBLIC)
+
+    PHP_ME(Session, __debugInfo,      arginfo___debugInfo,        ZEND_ACC_PUBLIC)
 
     PHP_FE_END
 };

--- a/pkcs11session.c
+++ b/pkcs11session.c
@@ -183,6 +183,18 @@ PHP_METHOD(Session, logout) {
     }
 }
 
+CK_RV php_C_SeedRandom(const pkcs11_session_object * const objval, zend_string *php_pSeed, zval *retval) {
+    CK_BYTE_PTR pSeed = (CK_BYTE_PTR)ZSTR_VAL(php_pSeed);
+    CK_ULONG ulSeedLen = (CK_ULONG)ZSTR_LEN(php_pSeed);
+    CK_RV rv;
+
+    rv = objval->pkcs11->functionList->C_SeedRandom(objval->session, pSeed, ulSeedLen);
+    if (rv != CKR_OK)
+        return rv;
+
+    return rv;
+}
+
 CK_RV php_C_GenerateRandom(const pkcs11_session_object * const objval, zend_long php_RandomLen, zval *retval) {
     CK_BYTE_PTR pRandomData;
     CK_ULONG ulRandomLen = (CK_ULONG)php_RandomLen;

--- a/pkcs11session.c
+++ b/pkcs11session.c
@@ -21,11 +21,13 @@
 zend_class_entry *ce_Pkcs11_Session;
 static zend_object_handlers pkcs11_session_handlers;
 
+#if 0
 ZEND_BEGIN_ARG_INFO_EX(arginfo___construct, 0, 0, 1)
     ZEND_ARG_TYPE_INFO(0, module, IS_OBJECT, 0)
     ZEND_ARG_TYPE_INFO(0, slotID, IS_LONG, 0)
     ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
+#endif
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_getInfo, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -84,6 +86,8 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_destroyObject, 0, 0, 1)
     ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
+#if 0
+#error use C_OpenSession()
 extern zend_class_entry *ce_Pkcs11_Module;
 PHP_METHOD(Session, __construct) {
     pkcs11_session_object *objval = Z_PKCS11_SESSION_P(ZEND_THIS);
@@ -126,6 +130,7 @@ PHP_METHOD(Session, __construct) {
     }
     objval->session = hSession;
 }
+#endif
 
 PHP_METHOD(Session, getInfo) {
 
@@ -611,7 +616,9 @@ void pkcs11_session_shutdown(pkcs11_session_object *obj) {
 }
 
 static zend_function_entry session_class_functions[] = {
+#if 0
     PHP_ME(Session, __construct,      arginfo___construct,      ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
+#endif
     PHP_ME(Session, login,            arginfo_login,            ZEND_ACC_PUBLIC)
     PHP_ME(Session, getInfo,          arginfo_getInfo,          ZEND_ACC_PUBLIC)
     PHP_ME(Session, logout,           arginfo_logout,           ZEND_ACC_PUBLIC)

--- a/pkcs11session.c
+++ b/pkcs11session.c
@@ -183,6 +183,26 @@ PHP_METHOD(Session, logout) {
     }
 }
 
+CK_RV php_C_GenerateRandom(const pkcs11_session_object * const objval, zend_long php_RandomLen, zval *retval) {
+    CK_BYTE_PTR pRandomData;
+    CK_ULONG ulRandomLen = (CK_ULONG)php_RandomLen;
+    CK_RV rv;
+
+    if (ulRandomLen < 1)
+        return CKR_ARGUMENTS_BAD;
+
+    pRandomData = (CK_BYTE_PTR)ecalloc(sizeof(*pRandomData), ulRandomLen);
+
+    rv = objval->pkcs11->functionList->C_GenerateRandom(objval->session, pRandomData, ulRandomLen);
+    if (rv != CKR_OK)
+        return rv;
+
+    ZVAL_STRINGL(retval, (char *)pRandomData, ulRandomLen);
+    efree(pRandomData);
+
+    return rv;
+}
+
 PHP_METHOD(Session, initPin) {
 
     CK_RV rv;
@@ -632,6 +652,7 @@ static zend_function_entry session_class_functions[] = {
     PHP_ME(Session, initializeDigest, arginfo_initializeDigest, ZEND_ACC_PUBLIC)
     PHP_ME(Session, generateKey,      arginfo_generateKey,      ZEND_ACC_PUBLIC)
     PHP_ME(Session, generateKeyPair,  arginfo_generateKeyPair,  ZEND_ACC_PUBLIC)
+
     PHP_FE_END
 };
 

--- a/pkcs11session.c
+++ b/pkcs11session.c
@@ -27,9 +27,6 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo___construct, 0, 0, 1)
     ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo___destruct, 0, 0, 0)
-ZEND_END_ARG_INFO()
-
 ZEND_BEGIN_ARG_INFO_EX(arginfo_getInfo, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
@@ -128,16 +125,6 @@ PHP_METHOD(Session, __construct) {
           return;
     }
     objval->session = hSession;
-}
-
-PHP_METHOD(Session, __destruct) {
-    pkcs11_session_object *objval = Z_PKCS11_SESSION_P(ZEND_THIS);
-
-    CK_RV rv;
-
-    rv = objval->pkcs11->functionList->C_CloseSession(objval->session);
-    if (rv != CKR_OK)
-        pkcs11_error(rv, "could not be C_CloseSession()'d");
 }
 
 PHP_METHOD(Session, getInfo) {
@@ -617,6 +604,7 @@ PHP_METHOD(Session, destroyObject) {
 
 void pkcs11_session_shutdown(pkcs11_session_object *obj) {
     // called before the pkcs11_session_object is freed
+    // TBC: is it called before pkcs11_shutdown() ? It has to.
     if (obj->pkcs11->functionList != NULL) {
         obj->pkcs11->functionList->C_CloseSession(obj->session);
     }
@@ -624,7 +612,6 @@ void pkcs11_session_shutdown(pkcs11_session_object *obj) {
 
 static zend_function_entry session_class_functions[] = {
     PHP_ME(Session, __construct,      arginfo___construct,      ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
-    PHP_ME(Session, __destruct,       arginfo___destruct,       ZEND_ACC_PUBLIC)
     PHP_ME(Session, login,            arginfo_login,            ZEND_ACC_PUBLIC)
     PHP_ME(Session, getInfo,          arginfo_getInfo,          ZEND_ACC_PUBLIC)
     PHP_ME(Session, logout,           arginfo_logout,           ZEND_ACC_PUBLIC)

--- a/pkcs11session.c
+++ b/pkcs11session.c
@@ -21,6 +21,14 @@
 zend_class_entry *ce_Pkcs11_Session;
 static zend_object_handlers pkcs11_session_handlers;
 
+ZEND_BEGIN_ARG_INFO_EX(arginfo___construct, 0, 0, 1)
+    ZEND_ARG_TYPE_INFO(0, module, IS_OBJECT, 0)
+    ZEND_ARG_TYPE_INFO(0, slotID, IS_LONG, 0)
+    ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo___destruct, 0, 0, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_getInfo, 0, 0, 0)
 ZEND_END_ARG_INFO()
@@ -78,6 +86,59 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_destroyObject, 0, 0, 1)
     ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
+
+extern zend_class_entry *ce_Pkcs11_Module;
+PHP_METHOD(Session, __construct) {
+    pkcs11_session_object *objval = Z_PKCS11_SESSION_P(ZEND_THIS);
+    objval->session = 0; /* not initialized yet */
+
+    CK_SLOT_ID slotid;
+    CK_FLAGS flags;
+    CK_RV rv;
+
+    zval *php_pkcs11;
+    zend_long php_slotid = 0;
+    zend_long php_flags = 0;
+
+    ZEND_PARSE_PARAMETERS_START(3, 3)
+      Z_PARAM_OBJECT_OF_CLASS(php_pkcs11, ce_Pkcs11_Module)
+      Z_PARAM_LONG(php_slotid)
+      Z_PARAM_LONG(php_flags)
+    ZEND_PARSE_PARAMETERS_END();
+
+    objval->pkcs11 = Z_PKCS11_P(php_pkcs11);
+    slotid = (CK_SLOT_ID)php_slotid;
+    flags = (CK_FLAGS)php_flags;
+
+    if (flags &
+        (CKF_RW_SESSION || CKF_SERIAL_SESSION)) {
+      ; /* nope */
+    } else {
+      ; /* nope */
+    }
+
+    CK_SESSION_HANDLE hSession;
+    if (ZEND_NUM_ARGS() > 4)
+        rv = objval->pkcs11->functionList->C_OpenSession(slotid, flags, NULL, NULL, &hSession); /* TODO: add callbacks */
+    else
+        rv = objval->pkcs11->functionList->C_OpenSession(slotid, flags, NULL, NULL, &hSession); /* TODO: add callbacks */
+
+    if (rv != CKR_OK) {
+          pkcs11_error(rv, "Unable to instanciate a session");
+          return;
+    }
+    objval->session = hSession;
+}
+
+PHP_METHOD(Session, __destruct) {
+    pkcs11_session_object *objval = Z_PKCS11_SESSION_P(ZEND_THIS);
+
+    CK_RV rv;
+
+    rv = objval->pkcs11->functionList->C_CloseSession(objval->session);
+    if (rv != CKR_OK)
+        pkcs11_error(rv, "could not be C_CloseSession()'d");
+}
 
 PHP_METHOD(Session, getInfo) {
 
@@ -562,6 +623,8 @@ void pkcs11_session_shutdown(pkcs11_session_object *obj) {
 }
 
 static zend_function_entry session_class_functions[] = {
+    PHP_ME(Session, __construct,      arginfo___construct,      ZEND_ACC_PUBLIC | ZEND_ACC_CTOR)
+    PHP_ME(Session, __destruct,       arginfo___destruct,       ZEND_ACC_PUBLIC)
     PHP_ME(Session, login,            arginfo_login,            ZEND_ACC_PUBLIC)
     PHP_ME(Session, getInfo,          arginfo_getInfo,          ZEND_ACC_PUBLIC)
     PHP_ME(Session, logout,           arginfo_logout,           ZEND_ACC_PUBLIC)

--- a/tests/0060-oasis_Session.phpt
+++ b/tests/0060-oasis_Session.phpt
@@ -23,19 +23,21 @@ $module = new Pkcs11\Module($modulePath);
 $rv = $module->C_GetSlotList(true, $s);
 var_dump($rv);
 
-$rv => $module->C_OpenSession($s[0], Pkcs11\CRF_RW_SESSION, null, null, $session);
+$rv = $module->C_OpenSession($s[0], Pkcs11\CKF_SERIAL_SESSION, null, null, $session);
+var_dump($rv);
+var_dump($session);
 
 $pin = getenv('PHP11_PIN');
 if (strlen($pin) === 0)
   $pin = null; # Smart card without any pin code
 
-$rv = $module->C_Login($session, CKU_USER, $pin);
+$rv = $module->C_Login($session, Pkcs11\CKU_USER, $pin);
 var_dump($rv);
 
 $rv = $module->C_Logout($session);
 var_dump($rv);
 
-$rv => $module->C_CloseSession($session);
+$rv = $module->C_CloseSession($session);
 // or use unset($session); # aka C_CloseSession()
 
 printf("OK".PHP_EOL);

--- a/tests/0060-oasis_Session.phpt
+++ b/tests/0060-oasis_Session.phpt
@@ -1,0 +1,47 @@
+--TEST--
+OASIS Session Basic test - C_Login(), C_Logout(), C_SessionInfo()
+--SKIPIF--
+<?php
+if (!extension_loaded('pkcs11')) {
+  echo 'skip';
+}
+
+if (getenv('PHP11_MODULE') === false) {
+  echo 'skip';
+}
+
+if (getenv('PHP11_PIN') === false) {
+  echo 'skip';
+}
+?>
+--FILE--
+<?php declare(strict_types=1);
+
+$modulePath = getenv('PHP11_MODULE');
+$module = new Pkcs11\Module($modulePath);
+
+$rv = $module->C_GetSlotList(true, $s);
+var_dump($rv);
+
+$session = new Pkcs11\Session($module, $s[0], Pkcs11\CKF_RW_SESSION); # aka C_OpenSession()
+
+$pin = getenv('PHP11_PIN');
+if (strlen($pin) === 0)
+  $pin = null; # Smart card without any pin code
+
+$rv = $session->C_Login(CKU_USER, $pin);
+var_dump($rv);
+
+$rv = $session->C_Logout();
+var_dump($rv);
+
+unset($session); # aka C_CloseSession()
+
+printf("OK".PHP_EOL);
+
+?>
+--EXPECTF--
+int(0)
+int(0)
+int(0)
+OK

--- a/tests/0060-oasis_Session.phpt
+++ b/tests/0060-oasis_Session.phpt
@@ -26,6 +26,7 @@ var_dump($rv);
 $rv = $module->C_OpenSession($s[0], Pkcs11\CKF_SERIAL_SESSION, null, null, $session);
 var_dump($rv);
 var_dump($session);
+var_dump($session->getInfo());
 
 $pin = getenv('PHP11_PIN');
 if (strlen($pin) === 0)

--- a/tests/0060-oasis_Session.phpt
+++ b/tests/0060-oasis_Session.phpt
@@ -55,5 +55,13 @@ printf("OK".PHP_EOL);
 --EXPECTF--
 int(0)
 int(0)
+object(Pkcs11\Session)#2 (2) {
+  ["hSession"]=>
+  int(%d)
+  ["slotID"]=>
+  int(0)
+}
+int(0)
+int(0)
 int(0)
 OK

--- a/tests/0060-oasis_Session.phpt
+++ b/tests/0060-oasis_Session.phpt
@@ -1,5 +1,5 @@
 --TEST--
-OASIS Session Basic test - C_Login(), C_Logout(), C_SessionInfo()
+OASIS Session Basic test - C_OpenSession(), C_CloseSession(), C_Login(), C_Logout(), C_SessionInfo()
 --SKIPIF--
 <?php
 if (!extension_loaded('pkcs11')) {
@@ -23,19 +23,20 @@ $module = new Pkcs11\Module($modulePath);
 $rv = $module->C_GetSlotList(true, $s);
 var_dump($rv);
 
-$session = new Pkcs11\Session($module, $s[0], Pkcs11\CKF_RW_SESSION); # aka C_OpenSession()
+$rv => $module->C_OpenSession($s[0], Pkcs11\CRF_RW_SESSION, null, null, $session);
 
 $pin = getenv('PHP11_PIN');
 if (strlen($pin) === 0)
   $pin = null; # Smart card without any pin code
 
-$rv = $session->C_Login(CKU_USER, $pin);
+$rv = $module->C_Login($session, CKU_USER, $pin);
 var_dump($rv);
 
-$rv = $session->C_Logout();
+$rv = $module->C_Logout($session);
 var_dump($rv);
 
-unset($session); # aka C_CloseSession()
+$rv => $module->C_CloseSession($session);
+// or use unset($session); # aka C_CloseSession()
 
 printf("OK".PHP_EOL);
 

--- a/tests/0060-oasis_Session.phpt
+++ b/tests/0060-oasis_Session.phpt
@@ -26,7 +26,15 @@ var_dump($rv);
 $rv = $module->C_OpenSession($s[0], Pkcs11\CKF_SERIAL_SESSION, null, null, $session);
 var_dump($rv);
 var_dump($session);
-var_dump($session->getInfo());
+
+$rv = $module->C_GetSessionInfo($session, $pInfo);
+var_dump($rv);
+
+if ($session->getInfo() !== $pInfo) {
+  printf("Error getInfo() vs C_GetSessionInfo()".PHP_EOL);
+  print_r($session->getInfo());
+  print_r($pInfo);
+}
 
 $pin = getenv('PHP11_PIN');
 if (strlen($pin) === 0)

--- a/tests/0070-oasis_Random.phpt
+++ b/tests/0070-oasis_Random.phpt
@@ -23,7 +23,10 @@ var_dump($rv);
 $rv = $module->C_OpenSession($s[0], Pkcs11\CKF_SERIAL_SESSION, null, null, $session);
 // TBC $session = new Pkcs11\Session($module, $s[0], Pkcs11\CKF_SERIAL_SESSION); # aka C_OpenSession()
 
-/* TODO: C_SeedRandom() */
+$rv = $module->C_SeedRandom($session, '1603soixantedix8');
+if ($rv === Pkcs11\CKR_RANDOM_SEED_NOT_SUPPORTED)
+  $rv = 0; # XXX fake, ignore any smart cards that do not support SeedRandom
+var_dump($rv);
 
 $rv = $module->C_GenerateRandom($session, 64, $rand);
 var_dump($rv);
@@ -31,6 +34,7 @@ printf("rand len=%d".PHP_EOL, strlen($rand));
 
 ?>
 --EXPECTF--
+int(0)
 int(0)
 int(0)
 rand len=64

--- a/tests/0070-oasis_Random.phpt
+++ b/tests/0070-oasis_Random.phpt
@@ -1,0 +1,36 @@
+--TEST--
+OASIS Session Basic test - C_SeedRandom(), C_GenerateRandom()
+--SKIPIF--
+<?php
+if (!extension_loaded('pkcs11')) {
+  echo 'skip';
+}
+
+if (getenv('PHP11_MODULE') === false) {
+  echo 'skip';
+}
+
+?>
+--FILE--
+<?php declare(strict_types=1);
+
+$modulePath = getenv('PHP11_MODULE');
+$module = new Pkcs11\Module($modulePath);
+
+$rv = $module->C_GetSlotList(true, $s);
+var_dump($rv);
+
+$rv = $module->C_OpenSession($s[0], Pkcs11\CKF_SERIAL_SESSION, null, null, $session);
+// TBC $session = new Pkcs11\Session($module, $s[0], Pkcs11\CKF_SERIAL_SESSION); # aka C_OpenSession()
+
+/* TODO: C_SeedRandom() */
+
+$rv = $module->C_GenerateRandom($session, 64, $rand);
+var_dump($rv);
+printf("rand len=%d".PHP_EOL, strlen($rand));
+
+?>
+--EXPECTF--
+int(0)
+int(0)
+rand len=64


### PR DESCRIPTION
This new serie support the OASIS C_*() methods only from the Module's method.

For sure, it will be easier to get a proper understanding from the OASIS documentation/specification, but it leads to some design complexities due to the PHP's garbage collector and the sequence to the shutdown() (or dtor()): for instance, the pkcs11_shutdown() shall be called only after any other shutdown().

Currently, it passes all the unit tests (7 PASSED).