### PR TITLE
Fix SetPin with HSM

### DIFF
--- a/tests/0110-login-change-own-pin-user.phpt
+++ b/tests/0110-login-change-own-pin-user.phpt
@@ -1,5 +1,8 @@
 --TEST--
 Change own PIN as User
+--DESCRIPTION--
+This test scenario detects that a wrong PIN is used, then it
+sets the proper PIN to PHP11_PIN once again.
 --SKIPIF--
 <?php
 
@@ -34,7 +37,7 @@ try {
 
 declare(strict_types=1);
 
-$newPin = '654321';
+$newPin = '4321';
 
 
 $module = new Pkcs11\Module(getenv('PHP11_MODULE'));

--- a/tests/0110-login-change-own-pin-user.phpt
+++ b/tests/0110-login-change-own-pin-user.phpt
@@ -37,10 +37,10 @@ try {
 
 declare(strict_types=1);
 
-$newPin = '4321';
-
-
 $module = new Pkcs11\Module(getenv('PHP11_MODULE'));
+$tokenInfo = $module->getTokenInfo((int)getenv('PHP11_SLOT'));
+$newPin = str_repeat('0', $tokenInfo['ulMaxPinLen']);
+
 $session = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
 
 try {


### PR DESCRIPTION
Most smartcards are limited to a pin length of 4 digits.

Fix error: 0x000000a2/CKR_PIN_LEN_RANGE

TBC: maybe we could use the ulMaxPinLen properties in order to limit the
length o the pin code.