### PR TITLE
Fix segfault generateKeyPair()

### DIFF
--- a/pkcs11session.c
+++ b/pkcs11session.c
@@ -382,8 +382,9 @@ PHP_METHOD(Session, generateKeyPair) {
     zval zskeyobj;
 
     rv = php_C_GenerateKeyPair(objval, mechanism, pkTemplate, skTemplate, &zpkeyobj, &zskeyobj);
+
     if (rv != CKR_OK) {
-        pkcs11_error(rv, "C_GenerateKeyPair()");
+        pkcs11_error(rv, "Unable to generate key pair");
         return ;
     }
 

--- a/pkcs11session.c
+++ b/pkcs11session.c
@@ -382,6 +382,10 @@ PHP_METHOD(Session, generateKeyPair) {
     zval zskeyobj;
 
     rv = php_C_GenerateKeyPair(objval, mechanism, pkTemplate, skTemplate, &zpkeyobj, &zskeyobj);
+    if (rv != CKR_OK) {
+        pkcs11_error(rv, "C_GenerateKeyPair()");
+        return ;
+    }
 
     object_init_ex(return_value, ce_Pkcs11_KeyPair);
     add_property_zval(return_value, "pkey", &zpkeyobj);


### PR DESCRIPTION
When the feature is not supported by the PKCS11 driver, an exception
should be rised.

Thanks to this fix, we get:
Fatal error: Uncaught Exception: (0x00000054/CKR_FUNCTION_NOT_SUPPORTED) PKCS#11 module error: C_GenerateKeyPair() in php-pkcs11/tests/0160-rsa-encrypt-pkcs.php:19
Stack trace:
  #0 php-pkcs11/tests/0160-rsa-encrypt-pkcs.php(19): Pkcs11\Session->generateKeyPair(Object(Pkcs11\Mechanism), Array, Array)
  #1 {main}
    thrown in php-pkcs11/tests/0160-rsa-encrypt-pkcs.php on line 19

Fix: Issue #39