### PR TITLE
Skip tests when OASIS C_CreateObject() unsupported

### DIFF
--- a/tests/0112-create-object.phpt
+++ b/tests/0112-create-object.phpt
@@ -5,6 +5,8 @@ Create object and retrieve attributes
 
 require_once 'require-userpin-login.skipif.inc';
 
+require_once 'require-create-object.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0113-copy-object.phpt
+++ b/tests/0113-copy-object.phpt
@@ -5,6 +5,8 @@ Copy object and retrieve attributes
 
 require_once 'require-userpin-login.skipif.inc';
 
+require_once 'require-create-object.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0114-destroy-object.phpt
+++ b/tests/0114-destroy-object.phpt
@@ -5,6 +5,8 @@ Destroy object and try to retrieve attributes
 
 require_once 'require-userpin-login.skipif.inc';
 
+require_once 'require-create-object.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0115-find-object.phpt
+++ b/tests/0115-find-object.phpt
@@ -5,6 +5,8 @@ Find object and retrieve attributes
 
 require_once 'require-userpin-login.skipif.inc';
 
+require_once 'require-create-object.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0130-hmac-sha1.phpt
+++ b/tests/0130-hmac-sha1.phpt
@@ -9,6 +9,8 @@ if (!in_array(Pkcs11\CKM_SHA_1_HMAC, $module->getMechanismList((int)getenv('PHP1
 	echo 'skip: CKM_SHA_1_HMAC not supported ';
 }
 
+require_once 'require-create-object.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0131-hmac-sha256.phpt
+++ b/tests/0131-hmac-sha256.phpt
@@ -9,6 +9,8 @@ if (!in_array(Pkcs11\CKM_SHA256_HMAC, $module->getMechanismList((int)getenv('PHP
 	echo 'skip: CKM_SHA256_HMAC not supported ';
 }
 
+require_once 'require-create-object.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0132-hmac-sha384.phpt
+++ b/tests/0132-hmac-sha384.phpt
@@ -9,6 +9,8 @@ if (!in_array(Pkcs11\CKM_SHA384_HMAC, $module->getMechanismList((int)getenv('PHP
 	echo 'skip: CKM_SHA384_HMAC not supported ';
 }
 
+require_once 'require-create-object.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0133-hmac-sha512.phpt
+++ b/tests/0133-hmac-sha512.phpt
@@ -9,6 +9,8 @@ if (!in_array(Pkcs11\CKM_SHA512_HMAC, $module->getMechanismList((int)getenv('PHP
 	echo 'skip: CKM_SHA512_HMAC not supported ';
 }
 
+require_once 'require-create-object.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0145-sym-encrypt-aes-gcm-update.phpt
+++ b/tests/0145-sym-encrypt-aes-gcm-update.phpt
@@ -9,6 +9,8 @@ if (!in_array(Pkcs11\CKM_AES_GCM, $module->getMechanismList((int)getenv('PHP11_S
 	echo 'skip: CKM_AES_GCM not supported ';
 }
 
+require_once 'require-create-object.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0151-sha256-update.phpt
+++ b/tests/0151-sha256-update.phpt
@@ -9,6 +9,8 @@ if (!in_array(Pkcs11\CKM_SHA256, $module->getMechanismList((int)getenv('PHP11_SL
 	echo 'skip: CKM_SHA256 not supported ';
 }
 
+require_once 'require-create-object.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0290-oasis_FindObjects.phpt
+++ b/tests/0290-oasis_FindObjects.phpt
@@ -13,6 +13,9 @@ if (getenv('PHP11_MODULE') === false) {
 if (getenv('PHP11_PIN') === false) {
   echo 'skip';
 }
+
+require_once 'require-create-object.skipif.inc';
+
 ?>
 --FILE--
 <?php declare(strict_types=1);

--- a/tests/require-create-object.skipif.inc
+++ b/tests/require-create-object.skipif.inc
@@ -1,0 +1,12 @@
+<?php
+
+require_once 'require-open-session.skipif.inc';
+
+$o11 = new Pkcs11\P11Object();
+
+try {
+    $rv = $module->C_CreateObject($session, array(), $o11);
+    if ($rv === Pkcs11\CKR_FUNCTION_NOT_SUPPORTED)
+        echo 'skip - C_CreateObject CKR_FUNCTION_NOT_SUPPORTED';
+} catch (\Throwable $e) {
+}

--- a/tests/require-create-object.skipif.inc
+++ b/tests/require-create-object.skipif.inc
@@ -2,10 +2,8 @@
 
 require_once 'require-open-session.skipif.inc';
 
-$o11 = new Pkcs11\P11Object();
-
 try {
-    $rv = $module->C_CreateObject($session, array(), $o11);
+    $rv = $module->C_CreateObject($session, [], $o11);
     if ($rv === Pkcs11\CKR_FUNCTION_NOT_SUPPORTED)
         echo 'skip - C_CreateObject CKR_FUNCTION_NOT_SUPPORTED';
 } catch (\Throwable $e) {


### PR DESCRIPTION
When some tests require C_CreateObject() that is not supported
by the HSM, they should be skipped.

Fix: Issue #41