### PR TITLE
Fix and skip C_GenerateKeyPair() if unsupported

### DIFF
--- a/pkcs11module.c
+++ b/pkcs11module.c
@@ -1156,9 +1156,14 @@ PHP_METHOD(Module, C_GenerateKeyPair) {
     pkcs11_session_object *sessionobjval = Z_PKCS11_SESSION_P(session);
 
     rv = php_C_GenerateKeyPair(sessionobjval, mechanism, pkTemplate, skTemplate, &retvalpk, &retvalsk);
+
+    if (rv != CKR_OK)
+        goto fini;
+
     ZEND_TRY_ASSIGN_REF_VALUE(phPublicKey, &retvalpk);
     ZEND_TRY_ASSIGN_REF_VALUE(phPrivateKey, &retvalsk);
 
+fini:
     RETURN_LONG(rv);
 }
 

--- a/tests/0160-rsa-encrypt-pkcs.phpt
+++ b/tests/0160-rsa-encrypt-pkcs.phpt
@@ -9,6 +9,8 @@ if (!in_array(Pkcs11\CKM_RSA_PKCS, $module->getMechanismList((int)getenv('PHP11_
 	echo 'skip: CKM_RSA_PKCS not supported ';
 }
 
+require_once 'require-generate-key-pair.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0161-rsa-encrypt-oaep.phpt
+++ b/tests/0161-rsa-encrypt-oaep.phpt
@@ -9,6 +9,8 @@ if (!in_array(Pkcs11\CKM_RSA_PKCS_OAEP, $module->getMechanismList((int)getenv('P
 	echo 'skip: CKM_RSA_PKCS_OAEP not supported ';
 }
 
+require_once 'require-generate-key-pair.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0162-rsa-sign-pkcs.phpt
+++ b/tests/0162-rsa-sign-pkcs.phpt
@@ -9,6 +9,8 @@ if (!in_array(Pkcs11\CKM_SHA256_RSA_PKCS, $module->getMechanismList((int)getenv(
 	echo 'skip: CKM_SHA256_RSA_PKCS not supported ';
 }
 
+require_once 'require-generate-key-pair.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0163-rsa-sign-pss.phpt
+++ b/tests/0163-rsa-sign-pss.phpt
@@ -9,6 +9,8 @@ if (!in_array(Pkcs11\CKM_SHA256_RSA_PKCS_PSS, $module->getMechanismList((int)get
 	echo 'skip: CKM_SHA256_RSA_PKCS_PSS not supported ';
 }
 
+require_once 'require-generate-key-pair.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0164-rsa-sign-pss-update.phpt
+++ b/tests/0164-rsa-sign-pss-update.phpt
@@ -9,6 +9,8 @@ if (!in_array(Pkcs11\CKM_SHA256_RSA_PKCS_PSS, $module->getMechanismList((int)get
 	echo 'skip: CKM_SHA256_RSA_PKCS_PSS not supported ';
 }
 
+require_once 'require-generate-key-pair.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0165-rsa-encrypt-oaep-wrap.phpt
+++ b/tests/0165-rsa-encrypt-oaep-wrap.phpt
@@ -13,6 +13,8 @@ if (!in_array(Pkcs11\CKM_AES_GCM, $module->getMechanismList((int)getenv('PHP11_S
 	echo 'skip: CKM_AES_GCM not supported ';
 }
 
+require_once 'require-generate-key-pair.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0170-ecdsa.phpt
+++ b/tests/0170-ecdsa.phpt
@@ -9,6 +9,8 @@ if (!in_array(Pkcs11\CKM_ECDSA, $module->getMechanismList((int)getenv('PHP11_SLO
 	echo 'skip: CKM_ECDSA not supported ';
 }
 
+require_once 'require-generate-key-pair.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0171-eddsa-25519.phpt
+++ b/tests/0171-eddsa-25519.phpt
@@ -9,6 +9,8 @@ if (!in_array(Pkcs11\CKM_EDDSA, $module->getMechanismList((int)getenv('PHP11_SLO
 	echo 'skip: CKM_EDDSA not supported ';
 }
 
+require_once 'require-generate-key-pair.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0172-eddsa-448.phpt
+++ b/tests/0172-eddsa-448.phpt
@@ -9,6 +9,8 @@ if (!in_array(Pkcs11\CKM_EDDSA, $module->getMechanismList((int)getenv('PHP11_SLO
 	echo 'skip: CKM_EDDSA not supported ';
 }
 
+require_once 'require-generate-key-pair.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0173-ecdh.phpt
+++ b/tests/0173-ecdh.phpt
@@ -17,6 +17,8 @@ if (trim($info["manufacturerID"]) == 'SoftHSM'
 	echo 'skip: Known bug in this version of SoftHSM';
 }
 
+require_once 'require-generate-key-pair.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0174-X25519.phpt
+++ b/tests/0174-X25519.phpt
@@ -13,6 +13,8 @@ if (!in_array(Pkcs11\CKM_EC_EDWARDS_KEY_PAIR_GEN, $module->getMechanismList((int
 	echo 'skip: CKM_EC_EDWARDS_KEY_PAIR_GEN not supported ';
 }
 
+require_once 'require-generate-key-pair.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/0175-X448.phpt
+++ b/tests/0175-X448.phpt
@@ -13,6 +13,8 @@ if (!in_array(Pkcs11\CKM_EC_EDWARDS_KEY_PAIR_GEN, $module->getMechanismList((int
 	echo 'skip: CKM_EC_EDWARDS_KEY_PAIR_GEN not supported ';
 }
 
+require_once 'require-generate-key-pair.skipif.inc';
+
 ?>
 --FILE--
 <?php

--- a/tests/require-generate-key-pair.skipif.inc
+++ b/tests/require-generate-key-pair.skipif.inc
@@ -1,0 +1,12 @@
+<?php
+
+require_once 'require-open-session.skipif.inc';
+
+try {
+    $rv = $module->C_GenerateKeyPair($session,
+                      new Pkcs11\Mechanism(Pkcs11\CKM_RSA_PKCS_KEY_PAIR_GEN),
+                      [], [], $pubKey, $privKey);
+    if ($rv === Pkcs11\CKR_FUNCTION_NOT_SUPPORTED)
+        echo 'skip - C_GenerateKeyPair CKR_FUNCTION_NOT_SUPPORTED';
+} catch (\Throwable $e) {
+}


### PR DESCRIPTION
C_GenerateKeyPair() may not be supported by the HSM.

Skip any tests that do not support this feature.

Fix: Issue #39