### PR TITLE
C_GetAttributeValue() shall emit a standard error

### DIFF
--- a/pkcs11module.c
+++ b/pkcs11module.c
@@ -1791,7 +1791,7 @@ PHP_METHOD(Module, C_GetAttributeValue) {
         case CKR_OK:
             break; /* ok */
         default:
-            zend_throw_exception(zend_ce_exception, "error get size C_GetAttributeValue(): ", rv);
+            pkcs11_error(rv, "C_GetAttributeValue(), get size");
             freeTemplate(pTemplate);
             return ;
     }


### PR DESCRIPTION
Let's use the default pkcs11_error() message in order to have a standard
error message (error code along with its string format).