### PR TITLE
free memory before returning from function

### DIFF
--- a/pkcs11decryptioncontext.c
+++ b/pkcs11decryptioncontext.c
@@ -72,9 +72,9 @@ PHP_METHOD(DecryptionContext, update) {
         plaintext,
         plaintextLen
     );
-    RETURN_STR(returnval);
-
     efree(plaintext);
+
+    RETURN_STR(returnval);
 }
 
 PHP_METHOD(DecryptionContext, finalize) {
@@ -115,9 +115,9 @@ PHP_METHOD(DecryptionContext, finalize) {
         plaintext,
         plaintextLen
     );
-    RETURN_STR(returnval);
-
     efree(plaintext);
+
+    RETURN_STR(returnval);
 }
 
 void pkcs11_decryptioncontext_shutdown(pkcs11_decryptioncontext_object *obj) {

--- a/pkcs11digestcontext.c
+++ b/pkcs11digestcontext.c
@@ -114,9 +114,9 @@ PHP_METHOD(DigestContext, finalize) {
         digest,
         digestLen
     );
-    RETURN_STR(returnval);
- 
     efree(digest);
+
+    RETURN_STR(returnval);
 }
 
 void pkcs11_digestcontext_shutdown(pkcs11_digestcontext_object *obj) {

--- a/pkcs11encryptioncontext.c
+++ b/pkcs11encryptioncontext.c
@@ -72,9 +72,9 @@ PHP_METHOD(EncryptionContext, update) {
         ciphertext,
         ciphertextLen
     );
-    RETURN_STR(returnval);
-
     efree(ciphertext);
+
+    RETURN_STR(returnval);
 }
 
 PHP_METHOD(EncryptionContext, finalize) {
@@ -115,9 +115,9 @@ PHP_METHOD(EncryptionContext, finalize) {
         ciphertext,
         ciphertextLen
     );
-    RETURN_STR(returnval);
-
     efree(ciphertext);
+
+    RETURN_STR(returnval);
 }
 
 void pkcs11_encryptioncontext_shutdown(pkcs11_encryptioncontext_object *obj) {

--- a/pkcs11key.c
+++ b/pkcs11key.c
@@ -257,9 +257,9 @@ PHP_METHOD(Key, sign) {
         signature,
         signatureLen
     );
-    RETURN_STR(returnval);
- 
     efree(signature);
+
+    RETURN_STR(returnval);
 }
 
 
@@ -368,9 +368,9 @@ PHP_METHOD(Key, encrypt) {
         ciphertext,
         ciphertextLen
     );
-    RETURN_STR(returnval);
-
     efree(ciphertext);
+
+    RETURN_STR(returnval);
 }
 
 
@@ -431,9 +431,9 @@ PHP_METHOD(Key, decrypt) {
         plaintext,
         plaintextLen
     );
-    RETURN_STR(returnval);
-
     efree(plaintext);
+
+    RETURN_STR(returnval);
 }
 
 
@@ -487,9 +487,9 @@ PHP_METHOD(Key, wrap) {
         ciphertext,
         ciphertextLen
     );
-    RETURN_STR(returnval);
-
     efree(ciphertext);
+
+    RETURN_STR(returnval);
 }
 
 

--- a/pkcs11session.c
+++ b/pkcs11session.c
@@ -457,9 +457,9 @@ PHP_METHOD(Session, digest) {
         digest,
         digestLen
     );
-    RETURN_STR(returnval);
- 
     efree(digest);
+
+    RETURN_STR(returnval);
 }
 
 

--- a/pkcs11signaturecontext.c
+++ b/pkcs11signaturecontext.c
@@ -88,9 +88,9 @@ PHP_METHOD(SignatureContext, finalize) {
         signature,
         signatureLen
     );
-    RETURN_STR(returnval);
- 
     efree(signature);
+
+    RETURN_STR(returnval);
 }
 
 void pkcs11_signaturecontext_shutdown(pkcs11_signaturecontext_object *obj) {


### PR DESCRIPTION
The `RETURN_...` defines include a return, e.g.

    #define RETVAL_STR(s)	 ZVAL_STR(return_value, s)
    #define RETURN_STR(s)    do { RETVAL_STR(s); return; } while (0)

So any calls to free memory should be called before.