### PR TITLE
Fix test 0106-open-session

### DIFF
--- a/pkcs11module.c
+++ b/pkcs11module.c
@@ -735,7 +735,7 @@ PHP_METHOD(Module, openSession) {
     CK_RV rv;
 
     zend_long      slotid;
-    zend_long      flags;
+    zend_long      flags = 0;
     zend_string    *application;
     zend_fcall_info php_fciNotify;
     zend_fcall_info_cache fciNotify_cache;


### PR DESCRIPTION
From time to time this test is failing because the flags
are optional but a random value is set to C_OpenSession()