### PR TITLE
Revise errors

### DIFF
--- a/pkcs11.c
+++ b/pkcs11.c
@@ -19,6 +19,7 @@
 #include "pkcs11int.h"
 
 static const char * strCK_RV(const CK_RV rv);
+static zend_class_entry *zend_pkcs11_exception_ce;
 
 void general_error(char *generic, char *specific) {
     char buf[BUFSIZ];
@@ -30,7 +31,7 @@ void pkcs11_error(CK_RV rv, char *error) {
     char buf[BUFSIZ];
     snprintf(buf, sizeof(buf), "(0x%08lx/%s) PKCS#11 module error: %s",
                                rv, strCK_RV(rv), error);
-    zend_throw_exception(zend_ce_exception, buf, 0);
+    zend_throw_exception(zend_pkcs11_exception_ce, buf, rv);
 }
 
 static const char * strCK_RV(const CK_RV rv) {
@@ -230,6 +231,11 @@ PHP_MINIT_FUNCTION(pkcs11)
     register_pkcs11_digestcontext();
     register_pkcs11_encryptioncontext();
     register_pkcs11_decryptioncontext();
+
+    zend_class_entry ce;
+
+    INIT_NS_CLASS_ENTRY(ce, "Pkcs11", "Exception", NULL);
+    zend_pkcs11_exception_ce = zend_register_internal_class_ex(&ce, zend_ce_exception);
 
     # define REGISTER_PKCS11_CONSTANT(n) REGISTER_NS_LONG_CONSTANT("Pkcs11", #n, n, CONST_CS | CONST_PERSISTENT)
     

--- a/pkcs11.c
+++ b/pkcs11.c
@@ -24,7 +24,7 @@ static zend_class_entry *zend_pkcs11_exception_ce;
 void general_error(char *generic, char *specific) {
     char buf[BUFSIZ];
     snprintf(buf, sizeof(buf), "%s: %s", generic, specific);
-    zend_throw_exception(zend_ce_exception, buf, 0);
+    zend_throw_exception(zend_pkcs11_exception_ce, buf, 0);
 }
 
 void pkcs11_error(CK_RV rv, char *error) {

--- a/pkcs11module.c
+++ b/pkcs11module.c
@@ -794,7 +794,7 @@ PHP_METHOD(Module, waitForSlotEvent) {
         RETURN_NULL();
     }
 
-    zend_throw_exception(zend_ce_exception, "Error waiting for events", 0);
+    pkcs11_error(rv, "Error waiting for events");
 }
 
 /*

--- a/tests/0117-waitForSlotEvent.phpt
+++ b/tests/0117-waitForSlotEvent.phpt
@@ -26,8 +26,12 @@ if (trim($info["manufacturerID"]) == 'SoftHSM'
 
 $modulePath = getenv('PHP11_MODULE');
 $module = new Pkcs11\Module($modulePath);
-$slotId = $module->waitForSlotEvent(Pkcs11\CKF_DONT_BLOCK);
-var_dump(is_int($slotId) || $slotId === null);
+try {
+	$slotId = $module->waitForSlotEvent(Pkcs11\CKF_DONT_BLOCK);
+	var_dump(is_int($slotId) || $slotId === null);
+} catch (\Pkcs11\Exception $e) {
+	var_dump($e->getCode() == \Pkcs11\CKR_FUNCTION_NOT_SUPPORTED);
+}
 
 ?>
 --EXPECTF--


### PR DESCRIPTION
@vjardin This fixes the error in the CI tests we've been seeing recently. Somehow, the bundled softhsm2 now returns unsupported_function error on waitforslotevent.