### PR TITLE
use ZEND_ACC_NOT_SERIALIZABLE for PHP 8.1

### DIFF
--- a/pkcs11int.h
+++ b/pkcs11int.h
@@ -192,6 +192,19 @@ DECLARE_MAGIC_FUNCS(pkcs11_digestcontext,                 DigestContext)
 DECLARE_MAGIC_FUNCS(pkcs11_encryptioncontext,             EncryptionContext)
 DECLARE_MAGIC_FUNCS(pkcs11_decryptioncontext,             DecryptionContext)
 
+#if PHP_VERSION_ID < 80100
+
+#define PKCS11_ACC_NOT_SERIALIZABLE(ce) \
+    ce->serialize = zend_class_serialize_deny; \
+    ce->unserialize = zend_class_unserialize_deny;
+
+#else
+
+#define PKCS11_ACC_NOT_SERIALIZABLE(ce) \
+    ce->ce_flags |= ZEND_ACC_NOT_SERIALIZABLE;
+
+#endif
+
 #define DEFINE_MAGIC_FUNCS(tt, lowername, classname)                            \
 static zend_object *tt##_ctor(zend_class_entry *ce) {                           \
     tt##_object *objval = zend_object_alloc(sizeof(tt##_object), ce);           \
@@ -216,8 +229,7 @@ void register_##tt() {                                                          
     tt##_handlers.clone_obj = NULL;                                             \
     tt##_handlers.free_obj = tt##_dtor;                                         \
     ce_Pkcs11_##classname = zend_register_internal_class(&ce);                  \
-    ce_Pkcs11_##classname->serialize = zend_class_serialize_deny;               \
-    ce_Pkcs11_##classname->unserialize = zend_class_unserialize_deny;           \
+    PKCS11_ACC_NOT_SERIALIZABLE(ce_Pkcs11_##classname);                         \
 }
 
 

--- a/pkcs11key.c
+++ b/pkcs11key.c
@@ -612,6 +612,5 @@ void register_pkcs11_key() {
     pkcs11_key_handlers.offset = XtOffsetOf(pkcs11_key_object, std);
     pkcs11_key_handlers.clone_obj = NULL;
     ce_Pkcs11_Key = zend_register_internal_class_ex(&ce, ce_Pkcs11_P11Object);
-    ce_Pkcs11_Key->serialize = zend_class_serialize_deny;
-    ce_Pkcs11_Key->unserialize = zend_class_unserialize_deny;
+    PKCS11_ACC_NOT_SERIALIZABLE(ce_Pkcs11_Key);
 }


### PR DESCRIPTION
```
PHP_VERSION : 8.1.0RC1

=====================================================================
TEST RESULT SUMMARY
---------------------------------------------------------------------
Exts skipped    :    0
Exts tested     :   16
---------------------------------------------------------------------

Number of tests :   56                50
Tests skipped   :    6 ( 10.7%) --------
Tests warned    :    0 (  0.0%) (  0.0%)
Tests failed    :    0 (  0.0%) (  0.0%)
Tests passed    :   50 ( 89.3%) (100.0%)
---------------------------------------------------------------------
Time taken      :    1 seconds
=====================================================================

```