### PR TITLE
feat: add ZTS support and persistent HSM session pooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ tests/*.sh
 example/vendor
 sandbox
 *.dep
+*~

--- a/php_pkcs11.h
+++ b/php_pkcs11.h
@@ -35,4 +35,41 @@ ZEND_TSRMLS_CACHE_EXTERN()
 
 #include "oasis/pkcs11.h"
 
+/* --- Phase 2: persistent connections --- */
+
+typedef struct _pkcs11_lib_record {
+    void                *dlhandle;
+    CK_FUNCTION_LIST_PTR functionList;
+    volatile bool        finalized;  /* set by MSHUTDOWN before C_Finalize */
+} pkcs11_lib_record;
+
+typedef struct _pkcs11_pooled_session {
+    CK_SESSION_HANDLE   handle;
+    pkcs11_lib_record  *lib;      /* for C_CloseSession + finalized check in dtor */
+    bool                in_use;   /* true = owned by a live PHP Session object */
+    bool                dead;     /* true = handle already closed / stale */
+} pkcs11_pooled_session;
+
+ZEND_BEGIN_MODULE_GLOBALS(pkcs11)
+    HashTable session_pool;  /* key: "realpath:slotID:flags" -> pkcs11_pooled_session* */
+ZEND_END_MODULE_GLOBALS(pkcs11)
+
+#ifdef ZTS
+# define PKCS11_G(v) ZEND_TSRMG(pkcs11_globals_id, zend_pkcs11_globals *, v)
+#else
+# define PKCS11_G(v) (pkcs11_globals.v)
+#endif
+
+ZEND_EXTERN_MODULE_GLOBALS(pkcs11)
+
+/* Process-wide library registry lock/unlock macros */
+extern pthread_mutex_t pkcs11_lib_mutex;
+#ifdef ZTS
+# define PKCS11_LIB_LOCK()   pthread_mutex_lock(&pkcs11_lib_mutex)
+# define PKCS11_LIB_UNLOCK() pthread_mutex_unlock(&pkcs11_lib_mutex)
+#else
+# define PKCS11_LIB_LOCK()   do { } while(0)
+# define PKCS11_LIB_UNLOCK() do { } while(0)
+#endif
+
 #endif	/* PHP_PKCS11_H */

--- a/pkcs11.c
+++ b/pkcs11.c
@@ -14,6 +14,40 @@
 
 #include "pkcs11int.h"
 
+#ifdef ZTS
+# include <pthread.h>
+#endif
+
+ZEND_DECLARE_MODULE_GLOBALS(pkcs11)
+
+/* Process-wide library registry — defined in pkcs11module.c */
+extern HashTable        pkcs11_libs;
+#ifdef ZTS
+extern pthread_mutex_t  pkcs11_lib_mutex;
+#endif
+extern bool             pkcs11_libs_initialized;
+
+static void pkcs11_globals_ctor(zend_pkcs11_globals *globals) {
+    zend_hash_init(&globals->session_pool, 8, NULL, NULL, 1);
+}
+
+static void pkcs11_globals_dtor(zend_pkcs11_globals *globals) {
+    pkcs11_pooled_session *entry;
+
+    ZEND_HASH_FOREACH_PTR(&globals->session_pool, entry) {
+        if (entry) {
+            if (!entry->dead && !entry->lib->finalized) {
+                /* Close session only if library is still alive.
+                 * MSHUTDOWN may have already called C_Finalize. */
+                entry->lib->functionList->C_CloseSession(entry->handle);
+            }
+            pefree(entry, 1);
+        }
+    } ZEND_HASH_FOREACH_END();
+
+    zend_hash_destroy(&globals->session_pool);
+}
+
 static const char * strCK_RV(const CK_RV rv);
 static zend_class_entry *zend_pkcs11_exception_ce;
 
@@ -209,6 +243,9 @@ void getObjectClass(pkcs11_session_object *session, CK_OBJECT_HANDLE_PTR hObject
 
 PHP_MINIT_FUNCTION(pkcs11)
 {
+    extern void pkcs11_lib_registry_init(void);
+    pkcs11_lib_registry_init();
+    ZEND_INIT_MODULE_GLOBALS(pkcs11, pkcs11_globals_ctor, pkcs11_globals_dtor);
     register_pkcs11();
     register_pkcs11_session();
     register_pkcs11_object();
@@ -1096,6 +1133,46 @@ PHP_MINIT_FUNCTION(pkcs11)
     return SUCCESS;
 }
 
+PHP_MSHUTDOWN_FUNCTION(pkcs11)
+{
+    if (pkcs11_libs_initialized) {
+        pkcs11_lib_record *lib;
+
+#ifndef ZTS
+        /* In non-ZTS, ZEND_INIT_MODULE_GLOBALS ignores the dtor argument,
+         * so globals_dtor never runs automatically.  Clean up explicitly. */
+        pkcs11_globals_dtor(&pkcs11_globals);
+#endif
+
+        PKCS11_LIB_LOCK();
+        ZEND_HASH_FOREACH_PTR(&pkcs11_libs, lib) {
+            lib->finalized = true;
+            lib->functionList->C_Finalize(NULL_PTR);
+            /* Do NOT dlclose or pefree(lib) here — globals_dtor may still
+             * reference lib->finalized.  Process is exiting; OS reclaims. */
+        } ZEND_HASH_FOREACH_END();
+
+#ifdef ZTS
+        /* In ZTS, pkcs11_globals_dtor was registered via ts_allocate_id() and
+         * would normally run during tsrm_shutdown().  However, tsrm_shutdown()
+         * is called AFTER zend_destroy_modules() has already unloaded this
+         * extension via DL_UNLOAD(), leaving the function pointer pointing at
+         * unmapped memory and causing a SIGSEGV on every PHP invocation.
+         * Fix: call ts_free_id() here while the .so is still mapped.  This
+         * runs the dtor for every thread (sessions are skipped because libs
+         * are already marked finalized above) and deregisters the destructor
+         * from TSRM so tsrm_shutdown() does not call it again. */
+        ts_free_id(pkcs11_globals_id);
+        pkcs11_globals_id = 0;
+#endif
+
+        zend_hash_destroy(&pkcs11_libs);
+        pkcs11_libs_initialized = false;
+        PKCS11_LIB_UNLOCK();
+    }
+
+    return SUCCESS;
+}
 
 PHP_MINFO_FUNCTION(pkcs11)
 {
@@ -1109,7 +1186,7 @@ zend_module_entry pkcs11_module_entry = {
     PHP_PKCS11_NAME,
     NULL,                           /* zend_function_entry */
     PHP_MINIT(pkcs11),              /* PHP_MINIT - Module initialization */
-    NULL,                           /* PHP_MSHUTDOWN - Module shutdown */
+    PHP_MSHUTDOWN(pkcs11),          /* PHP_MSHUTDOWN - Module shutdown */
     NULL,                           /* PHP_RINIT - Request initialization */
     NULL,                           /* PHP_RSHUTDOWN - Request shutdown */
     PHP_MINFO(pkcs11),              /* PHP_MINFO - Module info */

--- a/pkcs11decryptioncontext.c
+++ b/pkcs11decryptioncontext.c
@@ -36,27 +36,34 @@ PHP_METHOD(DecryptionContext, update) {
     pkcs11_decryptioncontext_object *objval = Z_PKCS11_DECRYPTIONCONTEXT_P(ZEND_THIS);
 
     CK_ULONG plaintextLen;
-    rv = objval->key->session->pkcs11->functionList->C_DecryptUpdate(
-        objval->key->session->session,
-        ZSTR_VAL(data),
-        ZSTR_LEN(data),
-        NULL_PTR ,
-        &plaintextLen
+    PKCS11_SESSION_EVICT(objval->key->session, rv,
+        objval->key->session->pkcs11->functionList->C_DecryptUpdate(
+            objval->key->session->session,
+            ZSTR_VAL(data),
+            ZSTR_LEN(data),
+            NULL_PTR ,
+            &plaintextLen
+        )
     );
     if (rv != CKR_OK) {
+        objval->key->session->tainted = false;
         pkcs11_error(rv, "Unable to update decryption");
         return;
     }
 
     CK_BYTE_PTR plaintext = ecalloc(plaintextLen, sizeof(CK_BYTE));
-    rv = objval->key->session->pkcs11->functionList->C_DecryptUpdate(
-        objval->key->session->session,
-        ZSTR_VAL(data),
-        ZSTR_LEN(data),
-        plaintext,
-        &plaintextLen
+    PKCS11_SESSION_EVICT(objval->key->session, rv,
+        objval->key->session->pkcs11->functionList->C_DecryptUpdate(
+            objval->key->session->session,
+            ZSTR_VAL(data),
+            ZSTR_LEN(data),
+            plaintext,
+            &plaintextLen
+        )
     );
     if (rv != CKR_OK) {
+        efree(plaintext);
+        objval->key->session->tainted = false;
         pkcs11_error(rv, "Unable to update decryption");
         return;
     }
@@ -83,23 +90,30 @@ PHP_METHOD(DecryptionContext, finalize) {
     pkcs11_decryptioncontext_object *objval = Z_PKCS11_DECRYPTIONCONTEXT_P(ZEND_THIS);
 
     CK_ULONG plaintextLen;
-    rv = objval->key->session->pkcs11->functionList->C_DecryptFinal(
-        objval->key->session->session,
-        NULL_PTR ,
-        &plaintextLen
+    PKCS11_SESSION_EVICT(objval->key->session, rv,
+        objval->key->session->pkcs11->functionList->C_DecryptFinal(
+            objval->key->session->session,
+            NULL_PTR ,
+            &plaintextLen
+        )
     );
     if (rv != CKR_OK) {
+        objval->key->session->tainted = false;
         pkcs11_error(rv, "Unable to finalize decryption");
         return;
     }
 
     CK_BYTE_PTR plaintext = ecalloc(plaintextLen, sizeof(CK_BYTE));
-    rv = objval->key->session->pkcs11->functionList->C_DecryptFinal(
-        objval->key->session->session,
-        plaintext,
-        &plaintextLen
+    PKCS11_SESSION_EVICT(objval->key->session, rv,
+        objval->key->session->pkcs11->functionList->C_DecryptFinal(
+            objval->key->session->session,
+            plaintext,
+            &plaintextLen
+        )
     );
     if (rv != CKR_OK) {
+        efree(plaintext);
+        objval->key->session->tainted = false;
         pkcs11_error(rv, "Unable to finalize decryption");
         return;
     }
@@ -113,6 +127,7 @@ PHP_METHOD(DecryptionContext, finalize) {
     );
     efree(plaintext);
 
+    objval->key->session->tainted = false;
     RETURN_STR(returnval);
 }
 

--- a/pkcs11digestcontext.c
+++ b/pkcs11digestcontext.c
@@ -39,12 +39,15 @@ PHP_METHOD(DigestContext, update) {
 
     pkcs11_digestcontext_object *objval = Z_PKCS11_DIGESTCONTEXT_P(ZEND_THIS);
 
-    rv = objval->session->pkcs11->functionList->C_DigestUpdate(
-        objval->session->session,
-        ZSTR_VAL(data),
-        ZSTR_LEN(data)
+    PKCS11_SESSION_EVICT(objval->session, rv,
+        objval->session->pkcs11->functionList->C_DigestUpdate(
+            objval->session->session,
+            ZSTR_VAL(data),
+            ZSTR_LEN(data)
+        )
     );
     if (rv != CKR_OK) {
+        objval->session->tainted = false;
         pkcs11_error(rv, "Unable to update digest");
         return;
     }
@@ -62,11 +65,14 @@ PHP_METHOD(DigestContext, keyUpdate) {
     pkcs11_digestcontext_object *objval = Z_PKCS11_DIGESTCONTEXT_P(ZEND_THIS);
     pkcs11_key_object *keyobjval = Z_PKCS11_KEY_P(key);
 
-    rv = objval->session->pkcs11->functionList->C_DigestKey(
-        objval->session->session,
-        keyobjval->key
+    PKCS11_SESSION_EVICT(objval->session, rv,
+        objval->session->pkcs11->functionList->C_DigestKey(
+            objval->session->session,
+            keyobjval->key
+        )
     );
     if (rv != CKR_OK) {
+        objval->session->tainted = false;
         pkcs11_error(rv, "Unable to update digest with key");
         return;
     }
@@ -82,23 +88,30 @@ PHP_METHOD(DigestContext, finalize) {
     pkcs11_digestcontext_object *objval = Z_PKCS11_DIGESTCONTEXT_P(ZEND_THIS);
 
     CK_ULONG digestLen;
-    rv = objval->session->pkcs11->functionList->C_DigestFinal(
-        objval->session->session,
-        NULL_PTR,
-        &digestLen
+    PKCS11_SESSION_EVICT(objval->session, rv,
+        objval->session->pkcs11->functionList->C_DigestFinal(
+            objval->session->session,
+            NULL_PTR,
+            &digestLen
+        )
     );
     if (rv != CKR_OK) {
+        objval->session->tainted = false;
         pkcs11_error(rv, "Unable to finalize digest");
         return;
     }
 
     CK_BYTE_PTR digest = ecalloc(digestLen, sizeof(CK_BYTE));
-    rv = objval->session->pkcs11->functionList->C_DigestFinal(
-        objval->session->session,
-        digest,
-        &digestLen
+    PKCS11_SESSION_EVICT(objval->session, rv,
+        objval->session->pkcs11->functionList->C_DigestFinal(
+            objval->session->session,
+            digest,
+            &digestLen
+        )
     );
     if (rv != CKR_OK) {
+        efree(digest);
+        objval->session->tainted = false;
         pkcs11_error(rv, "Unable to finalize digest");
         return;
     }
@@ -112,6 +125,7 @@ PHP_METHOD(DigestContext, finalize) {
     );
     efree(digest);
 
+    objval->session->tainted = false;
     RETURN_STR(returnval);
 }
 

--- a/pkcs11encryptioncontext.c
+++ b/pkcs11encryptioncontext.c
@@ -36,27 +36,34 @@ PHP_METHOD(EncryptionContext, update) {
     pkcs11_encryptioncontext_object *objval = Z_PKCS11_ENCRYPTIONCONTEXT_P(ZEND_THIS);
 
     CK_ULONG ciphertextLen;
-    rv = objval->key->session->pkcs11->functionList->C_EncryptUpdate(
-        objval->key->session->session,
-        ZSTR_VAL(data),
-        ZSTR_LEN(data),
-        NULL_PTR ,
-        &ciphertextLen
+    PKCS11_SESSION_EVICT(objval->key->session, rv,
+        objval->key->session->pkcs11->functionList->C_EncryptUpdate(
+            objval->key->session->session,
+            ZSTR_VAL(data),
+            ZSTR_LEN(data),
+            NULL_PTR ,
+            &ciphertextLen
+        )
     );
     if (rv != CKR_OK) {
+        objval->key->session->tainted = false;
         pkcs11_error(rv, "Unable to update encryption");
         return;
     }
 
     CK_BYTE_PTR ciphertext = ecalloc(ciphertextLen, sizeof(CK_BYTE));
-    rv = objval->key->session->pkcs11->functionList->C_EncryptUpdate(
-        objval->key->session->session,
-        ZSTR_VAL(data),
-        ZSTR_LEN(data),
-        ciphertext,
-        &ciphertextLen
+    PKCS11_SESSION_EVICT(objval->key->session, rv,
+        objval->key->session->pkcs11->functionList->C_EncryptUpdate(
+            objval->key->session->session,
+            ZSTR_VAL(data),
+            ZSTR_LEN(data),
+            ciphertext,
+            &ciphertextLen
+        )
     );
     if (rv != CKR_OK) {
+        efree(ciphertext);
+        objval->key->session->tainted = false;
         pkcs11_error(rv, "Unable to update encryption");
         return;
     }
@@ -83,23 +90,30 @@ PHP_METHOD(EncryptionContext, finalize) {
     pkcs11_encryptioncontext_object *objval = Z_PKCS11_ENCRYPTIONCONTEXT_P(ZEND_THIS);
 
     CK_ULONG ciphertextLen;
-    rv = objval->key->session->pkcs11->functionList->C_EncryptFinal(
-        objval->key->session->session,
-        NULL_PTR ,
-        &ciphertextLen
+    PKCS11_SESSION_EVICT(objval->key->session, rv,
+        objval->key->session->pkcs11->functionList->C_EncryptFinal(
+            objval->key->session->session,
+            NULL_PTR ,
+            &ciphertextLen
+        )
     );
     if (rv != CKR_OK) {
+        objval->key->session->tainted = false;
         pkcs11_error(rv, "Unable to finalize encryption");
         return;
     }
 
     CK_BYTE_PTR ciphertext = ecalloc(ciphertextLen, sizeof(CK_BYTE));
-    rv = objval->key->session->pkcs11->functionList->C_EncryptFinal(
-        objval->key->session->session,
-        ciphertext,
-        &ciphertextLen
+    PKCS11_SESSION_EVICT(objval->key->session, rv,
+        objval->key->session->pkcs11->functionList->C_EncryptFinal(
+            objval->key->session->session,
+            ciphertext,
+            &ciphertextLen
+        )
     );
     if (rv != CKR_OK) {
+        efree(ciphertext);
+        objval->key->session->tainted = false;
         pkcs11_error(rv, "Unable to finalize encryption");
         return;
     }
@@ -113,6 +127,7 @@ PHP_METHOD(EncryptionContext, finalize) {
     );
     efree(ciphertext);
 
+    objval->key->session->tainted = false;
     RETURN_STR(returnval);
 }
 

--- a/pkcs11int.h
+++ b/pkcs11int.h
@@ -36,17 +36,22 @@
 #endif
 
 typedef struct _pkcs11_object {
-    bool initialised;
-    void *pkcs11module;
-    CK_FUNCTION_LIST_PTR functionList;
-    zend_object std;
+    bool                  initialised;
+    void                 *pkcs11module;     /* = lib->dlhandle (call-site compat) */
+    CK_FUNCTION_LIST_PTR  functionList;     /* = lib->functionList (call-site compat) */
+    char                 *lib_path;         /* pemalloc'd realpath; key into pkcs11_libs */
+    pkcs11_lib_record    *lib;              /* direct pointer — avoids registry re-lookup */
+    zend_object           std;              /* MUST be last */
 } pkcs11_object;
 
 typedef struct _pkcs11_session_object {
-    pkcs11_object *pkcs11;
-    CK_SESSION_HANDLE session;
-    CK_SLOT_ID slotID;
-    zend_object std;
+    pkcs11_object          *pkcs11;
+    CK_SESSION_HANDLE       session;
+    CK_SLOT_ID              slotID;
+    CK_FLAGS                flags;          /* CKF_SERIAL_SESSION | user flags */
+    bool                    tainted;        /* true = active C_*Init; don't pool */
+    pkcs11_pooled_session  *pooled;         /* backpointer; NULL = not pooled */
+    zend_object             std;            /* MUST be last */
 } pkcs11_session_object;
 
 typedef struct _pkcs11_object_object {
@@ -245,5 +250,61 @@ extern CK_RV php_C_CreateObject(pkcs11_session_object *objval, HashTable *templa
 extern CK_RV php_C_CopyObject(pkcs11_session_object *objval, zval *objectOrig, HashTable *template, zval *retval);
 extern CK_RV php_C_DestroyObject(pkcs11_session_object *objval, zval *object);
 extern CK_RV php_C_FindObjects(pkcs11_session_object *objval,  CK_ATTRIBUTE *tmpl, int nbAttributes, zval *return_value);
+
+/* Phase 2: stale session eviction */
+extern void pkcs11_evict_session(pkcs11_session_object *sobj);
+
+/*
+ * PKCS11_SESSION_CALL — for C_*Init and single-shot calls.
+ * On stale-session errors: evict, open fresh session, retry once.
+ * Use this for stateless/init calls where retry is meaningful.
+ *
+ * WHY RETRY IS SAFE: The error codes CKR_SESSION_HANDLE_INVALID,
+ * CKR_SESSION_CLOSED, CKR_TOKEN_NOT_PRESENT, and CKR_DEVICE_REMOVED all
+ * indicate that the session was invalid BEFORE the call executed — the
+ * operation could not have partially completed.  Retrying on a fresh
+ * session is therefore idempotent and safe.
+ */
+#define PKCS11_SESSION_CALL(sobj, rv, call) do {                          \
+    (rv) = (call);                                                         \
+    if ((rv) == CKR_SESSION_HANDLE_INVALID ||                              \
+        (rv) == CKR_SESSION_CLOSED         ||                              \
+        (rv) == CKR_TOKEN_NOT_PRESENT      ||                              \
+        (rv) == CKR_DEVICE_REMOVED) {                                      \
+        pkcs11_evict_session(sobj);                                        \
+        CK_SESSION_HANDLE _new_h;                                          \
+        CK_RV _reopen = (sobj)->pkcs11->functionList->C_OpenSession(       \
+            (sobj)->slotID, CKF_SERIAL_SESSION | (sobj)->flags,            \
+            NULL_PTR, NULL_PTR, &_new_h);                                  \
+        if (_reopen == CKR_OK) {                                           \
+            (sobj)->session = _new_h;                                      \
+            if ((sobj)->pooled) {                                          \
+                (sobj)->pooled->handle = _new_h;                           \
+                (sobj)->pooled->dead = false;                              \
+                (sobj)->pooled->in_use = true;                             \
+            }                                                              \
+            (rv) = (call);                                                 \
+        }                                                                  \
+    }                                                                      \
+} while(0)
+
+/*
+ * PKCS11_SESSION_EVICT — for C_*Update / C_*Final (stateful calls).
+ * On stale errors: evict only, do NOT retry.  Retry is pointless for
+ * multipart operations because the new session has no prior Init/Update
+ * state.  The error propagates to PHP; caller handles it.
+ */
+#define PKCS11_SESSION_EVICT(sobj, rv, call) do {                         \
+    (rv) = (call);                                                         \
+    if ((rv) == CKR_SESSION_HANDLE_INVALID ||                              \
+        (rv) == CKR_SESSION_CLOSED         ||                              \
+        (rv) == CKR_TOKEN_NOT_PRESENT      ||                              \
+        (rv) == CKR_DEVICE_REMOVED) {                                      \
+        pkcs11_evict_session(sobj);                                        \
+    }                                                                      \
+} while(0)
+
+/* Phase 2: pool key helper (defined in pkcs11session.c) */
+extern void pkcs11_pool_mark_dead(CK_SESSION_HANDLE handle);
 
 #endif

--- a/pkcs11key.c
+++ b/pkcs11key.c
@@ -88,15 +88,18 @@ PHP_METHOD(Key, initializeSignature) {
     pkcs11_mechanism_object *mechanismObjval = Z_PKCS11_MECHANISM_P(mechanism);
 
     pkcs11_key_object *objval = Z_PKCS11_KEY_P(ZEND_THIS);
-    rv = objval->session->pkcs11->functionList->C_SignInit(
-        objval->session->session,
-        &mechanismObjval->mechanism,
-        objval->key
+    PKCS11_SESSION_CALL(objval->session, rv,
+        objval->session->pkcs11->functionList->C_SignInit(
+            objval->session->session,
+            &mechanismObjval->mechanism,
+            objval->key
+        )
     );
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to initialize signature");
         return;
     }
+    objval->session->tainted = true;
 
     pkcs11_signaturecontext_object* context_obj;
 
@@ -119,15 +122,18 @@ PHP_METHOD(Key, initializeVerification) {
     pkcs11_mechanism_object *mechanismObjval = Z_PKCS11_MECHANISM_P(mechanism);
 
     pkcs11_key_object *objval = Z_PKCS11_KEY_P(ZEND_THIS);
-    rv = objval->session->pkcs11->functionList->C_VerifyInit(
-        objval->session->session,
-        &mechanismObjval->mechanism,
-        objval->key
+    PKCS11_SESSION_CALL(objval->session, rv,
+        objval->session->pkcs11->functionList->C_VerifyInit(
+            objval->session->session,
+            &mechanismObjval->mechanism,
+            objval->key
+        )
     );
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to initialize verification");
         return;
     }
+    objval->session->tainted = true;
 
     pkcs11_verificationcontext_object* context_obj;
 
@@ -150,15 +156,18 @@ PHP_METHOD(Key, initializeEncryption) {
     pkcs11_mechanism_object *mechanismObjval = Z_PKCS11_MECHANISM_P(mechanism);
 
     pkcs11_key_object *objval = Z_PKCS11_KEY_P(ZEND_THIS);
-    rv = objval->session->pkcs11->functionList->C_EncryptInit(
-        objval->session->session,
-        &mechanismObjval->mechanism,
-        objval->key
+    PKCS11_SESSION_CALL(objval->session, rv,
+        objval->session->pkcs11->functionList->C_EncryptInit(
+            objval->session->session,
+            &mechanismObjval->mechanism,
+            objval->key
+        )
     );
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to initialize encryption");
         return;
     }
+    objval->session->tainted = true;
 
     pkcs11_encryptioncontext_object* context_obj;
 
@@ -181,15 +190,18 @@ PHP_METHOD(Key, initializeDecryption) {
     pkcs11_mechanism_object *mechanismObjval = Z_PKCS11_MECHANISM_P(mechanism);
 
     pkcs11_key_object *objval = Z_PKCS11_KEY_P(ZEND_THIS);
-    rv = objval->session->pkcs11->functionList->C_DecryptInit(
-        objval->session->session,
-        &mechanismObjval->mechanism,
-        objval->key
+    PKCS11_SESSION_CALL(objval->session, rv,
+        objval->session->pkcs11->functionList->C_DecryptInit(
+            objval->session->session,
+            &mechanismObjval->mechanism,
+            objval->key
+        )
     );
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to initialize decryption");
         return;
     }
+    objval->session->tainted = true;
 
     pkcs11_decryptioncontext_object* context_obj;
 
@@ -214,38 +226,48 @@ PHP_METHOD(Key, sign) {
     pkcs11_mechanism_object *mechanismObjval = Z_PKCS11_MECHANISM_P(mechanism);
 
     pkcs11_key_object *objval = Z_PKCS11_KEY_P(ZEND_THIS);
-    rv = objval->session->pkcs11->functionList->C_SignInit(
-        objval->session->session,
-        &mechanismObjval->mechanism,
-        objval->key
+    PKCS11_SESSION_CALL(objval->session, rv,
+        objval->session->pkcs11->functionList->C_SignInit(
+            objval->session->session,
+            &mechanismObjval->mechanism,
+            objval->key
+        )
     );
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to sign");
         return;
     }
+    objval->session->tainted = true;
     
     CK_ULONG signatureLen;
-    rv = objval->session->pkcs11->functionList->C_Sign(
-        objval->session->session,
-        ZSTR_VAL(data),
-        ZSTR_LEN(data),
-        NULL_PTR,
-        &signatureLen
+    PKCS11_SESSION_EVICT(objval->session, rv,
+        objval->session->pkcs11->functionList->C_Sign(
+            objval->session->session,
+            ZSTR_VAL(data),
+            ZSTR_LEN(data),
+            NULL_PTR,
+            &signatureLen
+        )
     );
     if (rv != CKR_OK) {
+        objval->session->tainted = false;
         pkcs11_error(rv, "Unable to sign");
         return;
     }
 
     CK_BYTE_PTR signature = ecalloc(signatureLen, sizeof(CK_BYTE));
-    rv = objval->session->pkcs11->functionList->C_Sign(
-        objval->session->session,
-        ZSTR_VAL(data),
-        ZSTR_LEN(data),
-        signature,
-        &signatureLen
+    PKCS11_SESSION_EVICT(objval->session, rv,
+        objval->session->pkcs11->functionList->C_Sign(
+            objval->session->session,
+            ZSTR_VAL(data),
+            ZSTR_LEN(data),
+            signature,
+            &signatureLen
+        )
     );
     if (rv != CKR_OK) {
+        efree(signature);
+        objval->session->tainted = false;
         pkcs11_error(rv, "Unable to sign");
         return;
     }
@@ -259,6 +281,7 @@ PHP_METHOD(Key, sign) {
     );
     efree(signature);
 
+    objval->session->tainted = false;
     RETURN_STR(returnval);
 }
 
@@ -279,34 +302,42 @@ PHP_METHOD(Key, verify) {
     pkcs11_mechanism_object *mechanismObjval = Z_PKCS11_MECHANISM_P(mechanism);
 
     pkcs11_key_object *objval = Z_PKCS11_KEY_P(ZEND_THIS);
-    rv = objval->session->pkcs11->functionList->C_VerifyInit(
-        objval->session->session,
-        &mechanismObjval->mechanism,
-        objval->key
+    PKCS11_SESSION_CALL(objval->session, rv,
+        objval->session->pkcs11->functionList->C_VerifyInit(
+            objval->session->session,
+            &mechanismObjval->mechanism,
+            objval->key
+        )
     );
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to verify");
         return;
     }
+    objval->session->tainted = true;
 
     CK_ULONG signatureLen;
-    rv = objval->session->pkcs11->functionList->C_Verify(
-        objval->session->session,
-        ZSTR_VAL(data),
-        ZSTR_LEN(data),
-        ZSTR_VAL(signature),
-        ZSTR_LEN(signature)
+    PKCS11_SESSION_EVICT(objval->session, rv,
+        objval->session->pkcs11->functionList->C_Verify(
+            objval->session->session,
+            ZSTR_VAL(data),
+            ZSTR_LEN(data),
+            ZSTR_VAL(signature),
+            ZSTR_LEN(signature)
+        )
     );
 
     if (rv == CKR_SIGNATURE_INVALID || rv == CKR_SIGNATURE_LEN_RANGE) {
+        objval->session->tainted = false;
         RETURN_BOOL(false);
     }
 
     if (rv != CKR_OK) {
+        objval->session->tainted = false;
         pkcs11_error(rv, "Unable to verify");
         return;
     }
 
+    objval->session->tainted = false;
     RETURN_BOOL(true);
 }
 
@@ -325,38 +356,48 @@ PHP_METHOD(Key, encrypt) {
     pkcs11_mechanism_object *mechanismObjval = Z_PKCS11_MECHANISM_P(mechanism);
 
     pkcs11_key_object *objval = Z_PKCS11_KEY_P(ZEND_THIS);
-    rv = objval->session->pkcs11->functionList->C_EncryptInit(
-        objval->session->session,
-        &mechanismObjval->mechanism,
-        objval->key
+    PKCS11_SESSION_CALL(objval->session, rv,
+        objval->session->pkcs11->functionList->C_EncryptInit(
+            objval->session->session,
+            &mechanismObjval->mechanism,
+            objval->key
+        )
     );
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to encrypt");
         return;
     }
+    objval->session->tainted = true;
 
     CK_ULONG ciphertextLen;
-    rv = objval->session->pkcs11->functionList->C_Encrypt(
-        objval->session->session,
-        ZSTR_VAL(plaintext),
-        ZSTR_LEN(plaintext),
-        NULL_PTR ,
-        &ciphertextLen
+    PKCS11_SESSION_EVICT(objval->session, rv,
+        objval->session->pkcs11->functionList->C_Encrypt(
+            objval->session->session,
+            ZSTR_VAL(plaintext),
+            ZSTR_LEN(plaintext),
+            NULL_PTR ,
+            &ciphertextLen
+        )
     );
     if (rv != CKR_OK) {
+        objval->session->tainted = false;
         pkcs11_error(rv, "Unable to encrypt");
         return;
     }
 
     CK_BYTE_PTR ciphertext = ecalloc(ciphertextLen, sizeof(CK_BYTE));
-    rv = objval->session->pkcs11->functionList->C_Encrypt(
-        objval->session->session,
-        ZSTR_VAL(plaintext),
-        ZSTR_LEN(plaintext),
-        ciphertext,
-        &ciphertextLen
+    PKCS11_SESSION_EVICT(objval->session, rv,
+        objval->session->pkcs11->functionList->C_Encrypt(
+            objval->session->session,
+            ZSTR_VAL(plaintext),
+            ZSTR_LEN(plaintext),
+            ciphertext,
+            &ciphertextLen
+        )
     );
     if (rv != CKR_OK) {
+        efree(ciphertext);
+        objval->session->tainted = false;
         pkcs11_error(rv, "Unable to encrypt");
         return;
     }
@@ -370,6 +411,7 @@ PHP_METHOD(Key, encrypt) {
     );
     efree(ciphertext);
 
+    objval->session->tainted = false;
     RETURN_STR(returnval);
 }
 
@@ -388,38 +430,48 @@ PHP_METHOD(Key, decrypt) {
     pkcs11_mechanism_object *mechanismObjval = Z_PKCS11_MECHANISM_P(mechanism);
 
     pkcs11_key_object *objval = Z_PKCS11_KEY_P(ZEND_THIS);
-    rv = objval->session->pkcs11->functionList->C_DecryptInit(
-        objval->session->session,
-        &mechanismObjval->mechanism,
-        objval->key
+    PKCS11_SESSION_CALL(objval->session, rv,
+        objval->session->pkcs11->functionList->C_DecryptInit(
+            objval->session->session,
+            &mechanismObjval->mechanism,
+            objval->key
+        )
     );
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to decrypt");
         return;
     }
+    objval->session->tainted = true;
 
     CK_ULONG plaintextLen;
-    rv = objval->session->pkcs11->functionList->C_Decrypt(
-        objval->session->session,
-        ZSTR_VAL(ciphertext),
-        ZSTR_LEN(ciphertext),
-        NULL_PTR,
-        &plaintextLen
+    PKCS11_SESSION_EVICT(objval->session, rv,
+        objval->session->pkcs11->functionList->C_Decrypt(
+            objval->session->session,
+            ZSTR_VAL(ciphertext),
+            ZSTR_LEN(ciphertext),
+            NULL_PTR,
+            &plaintextLen
+        )
     );
     if (rv != CKR_OK) {
+        objval->session->tainted = false;
         pkcs11_error(rv, "Unable to decrypt");
         return;
     }
 
     CK_BYTE_PTR plaintext = ecalloc(plaintextLen, sizeof(CK_BYTE));
-    rv = objval->session->pkcs11->functionList->C_Decrypt(
-        objval->session->session,
-        ZSTR_VAL(ciphertext),
-        ZSTR_LEN(ciphertext),
-        plaintext,
-        &plaintextLen
+    PKCS11_SESSION_EVICT(objval->session, rv,
+        objval->session->pkcs11->functionList->C_Decrypt(
+            objval->session->session,
+            ZSTR_VAL(ciphertext),
+            ZSTR_LEN(ciphertext),
+            plaintext,
+            &plaintextLen
+        )
     );
     if (rv != CKR_OK) {
+        efree(plaintext);
+        objval->session->tainted = false;
         pkcs11_error(rv, "Unable to decrypt");
         return;
     }
@@ -433,6 +485,7 @@ PHP_METHOD(Key, decrypt) {
     );
     efree(plaintext);
 
+    objval->session->tainted = false;
     RETURN_STR(returnval);
 }
 
@@ -453,13 +506,15 @@ PHP_METHOD(Key, wrap) {
     CK_ULONG ciphertextLen;
     pkcs11_key_object *objval = Z_PKCS11_KEY_P(ZEND_THIS);
     pkcs11_key_object *keyobjval = Z_PKCS11_KEY_P(key);
-    rv = objval->session->pkcs11->functionList->C_WrapKey(
-        objval->session->session,
-        &mechanismObjval->mechanism,
-        objval->key,
-        keyobjval->key,
-        NULL_PTR ,
-        &ciphertextLen
+    PKCS11_SESSION_CALL(objval->session, rv,
+        objval->session->pkcs11->functionList->C_WrapKey(
+            objval->session->session,
+            &mechanismObjval->mechanism,
+            objval->key,
+            keyobjval->key,
+            NULL_PTR ,
+            &ciphertextLen
+        )
     );
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to wrap");
@@ -467,13 +522,15 @@ PHP_METHOD(Key, wrap) {
     }
 
     CK_BYTE_PTR ciphertext = ecalloc(ciphertextLen, sizeof(CK_BYTE));
-    rv = objval->session->pkcs11->functionList->C_WrapKey(
-        objval->session->session,
-        &mechanismObjval->mechanism,
-        objval->key,
-        keyobjval->key,
-        ciphertext,
-        &ciphertextLen
+    PKCS11_SESSION_CALL(objval->session, rv,
+        objval->session->pkcs11->functionList->C_WrapKey(
+            objval->session->session,
+            &mechanismObjval->mechanism,
+            objval->key,
+            keyobjval->key,
+            ciphertext,
+            &ciphertextLen
+        )
     );
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to wrap");
@@ -515,15 +572,17 @@ PHP_METHOD(Key, unwrap) {
     pkcs11_mechanism_object *mechanismObjval = Z_PKCS11_MECHANISM_P(mechanism);
 
     pkcs11_key_object *objval = Z_PKCS11_KEY_P(ZEND_THIS);
-    rv = objval->session->pkcs11->functionList->C_UnwrapKey(
-        objval->session->session,
-        &mechanismObjval->mechanism,
-        objval->key,
-        ZSTR_VAL(ciphertext),
-        ZSTR_LEN(ciphertext),
-        templateObj,
-        templateItemCount,
-        &uhKey
+    PKCS11_SESSION_CALL(objval->session, rv,
+        objval->session->pkcs11->functionList->C_UnwrapKey(
+            objval->session->session,
+            &mechanismObjval->mechanism,
+            objval->key,
+            ZSTR_VAL(ciphertext),
+            ZSTR_LEN(ciphertext),
+            templateObj,
+            templateItemCount,
+            &uhKey
+        )
     );
     freeTemplate(templateObj);
     
@@ -562,13 +621,15 @@ PHP_METHOD(Key, derive) {
     pkcs11_mechanism_object *mechanismObjval = Z_PKCS11_MECHANISM_P(mechanism);
 
     pkcs11_key_object *objval = Z_PKCS11_KEY_P(ZEND_THIS);
-    rv = objval->session->pkcs11->functionList->C_DeriveKey(
-        objval->session->session,
-        &mechanismObjval->mechanism,
-        objval->key,
-        templateObj,
-        templateItemCount,
-        &phKey
+    PKCS11_SESSION_CALL(objval->session, rv,
+        objval->session->pkcs11->functionList->C_DeriveKey(
+            objval->session->session,
+            &mechanismObjval->mechanism,
+            objval->key,
+            templateObj,
+            templateItemCount,
+            &phKey
+        )
     );
     freeTemplate(templateObj);
 

--- a/pkcs11module.c
+++ b/pkcs11module.c
@@ -15,6 +15,22 @@
 #include "pkcs11int.h"
 #include "standard/php_string.h"
 
+#ifdef ZTS
+# include <pthread.h>
+#endif
+
+/* Process-wide library registry: realpath → pkcs11_lib_record* */
+HashTable        pkcs11_libs;
+#ifdef ZTS
+pthread_mutex_t  pkcs11_lib_mutex = PTHREAD_MUTEX_INITIALIZER;
+#endif
+bool             pkcs11_libs_initialized = false;
+
+void pkcs11_lib_registry_init(void) {
+    zend_hash_init(&pkcs11_libs, 4, NULL, NULL, 1);
+    pkcs11_libs_initialized = true;
+}
+
 zend_class_entry *ce_Pkcs11_Module;
 static zend_object_handlers pkcs11_handlers;
 
@@ -125,7 +141,6 @@ PHP_METHOD(Module, __construct) {
         Z_PARAM_PATH(module_path, module_path_len)
     ZEND_PARSE_PARAMETERS_END();
 
-
     pkcs11_object *objval = Z_PKCS11_P(ZEND_THIS);
 
     if (objval->initialised) {
@@ -133,10 +148,34 @@ PHP_METHOD(Module, __construct) {
         return;
     }
 
+    /* Canonicalize path; fall back to original on failure */
+    char resolved[PATH_MAX];
+    char *canonical = realpath(module_path, resolved);
+    if (canonical == NULL) {
+        canonical = module_path;
+    }
+    size_t canonical_len = strlen(canonical);
+
+    /* First check: lock and look up the registry */
+    PKCS11_LIB_LOCK();
+    pkcs11_lib_record *lib = zend_hash_str_find_ptr(&pkcs11_libs, canonical, canonical_len);
+    if (lib != NULL) {
+        /* Already initialized by another Module — reuse */
+        objval->pkcs11module = lib->dlhandle;
+        objval->functionList = lib->functionList;
+        objval->lib = lib;
+        objval->lib_path = pemalloc(canonical_len + 1, 1);
+        memcpy(objval->lib_path, canonical, canonical_len + 1);
+        objval->initialised = true;
+        PKCS11_LIB_UNLOCK();
+        return;
+    }
+    PKCS11_LIB_UNLOCK();
+
+    /* Not found — do slow work (dlopen) outside the lock */
     CK_RV rv;
-
-    char* dlerror_str;
-    objval->pkcs11module = dlopen(module_path, RTLD_NOW);
+    char *dlerror_str;
+    void *dlhandle = dlopen(module_path, RTLD_NOW);
 
     dlerror_str = dlerror();
     if (dlerror_str != NULL) {
@@ -144,25 +183,65 @@ PHP_METHOD(Module, __construct) {
         return;
     }
 
-    CK_C_GetFunctionList C_GetFunctionList = dlsym(objval->pkcs11module, "C_GetFunctionList");
+    CK_C_GetFunctionList C_GetFunctionList = dlsym(dlhandle, "C_GetFunctionList");
     dlerror_str = dlerror();
     if (dlerror_str != NULL) {
+        dlclose(dlhandle);
         general_error("Unable to initialise PKCS11 module", dlerror_str);
         return;
     }
 
-    rv = C_GetFunctionList(&objval->functionList);
+    CK_FUNCTION_LIST_PTR functionList;
+    rv = C_GetFunctionList(&functionList);
     if (rv != CKR_OK) {
+        dlclose(dlhandle);
         pkcs11_error(rv, "Unable to retrieve function list");
         return;
     }
 
-    rv = objval->functionList->C_Initialize(NULL);
-    if (rv != CKR_OK) {
+    /* Re-lock and double-check — another thread may have initialized */
+    PKCS11_LIB_LOCK();
+    lib = zend_hash_str_find_ptr(&pkcs11_libs, canonical, canonical_len);
+    if (lib != NULL) {
+        /* Race: another thread initialized while we were unlocked */
+        dlclose(dlhandle);
+        objval->pkcs11module = lib->dlhandle;
+        objval->functionList = lib->functionList;
+        objval->lib = lib;
+        objval->lib_path = pemalloc(canonical_len + 1, 1);
+        memcpy(objval->lib_path, canonical, canonical_len + 1);
+        objval->initialised = true;
+        PKCS11_LIB_UNLOCK();
+        return;
+    }
+
+    /* We're the first — initialize the library */
+#ifdef ZTS
+    CK_C_INITIALIZE_ARGS init_args = {NULL, NULL, NULL, NULL, CKF_OS_LOCKING_OK, NULL};
+    rv = functionList->C_Initialize(&init_args);
+#else
+    rv = functionList->C_Initialize(NULL);
+#endif
+    if (rv != CKR_OK && rv != CKR_CRYPTOKI_ALREADY_INITIALIZED) {
+        PKCS11_LIB_UNLOCK();
+        dlclose(dlhandle);
         pkcs11_error(rv, "Unable to initialise token");
         return;
     }
 
+    /* Insert into registry */
+    lib = pemalloc(sizeof(pkcs11_lib_record), 1);
+    lib->dlhandle     = dlhandle;
+    lib->functionList = functionList;
+    lib->finalized    = false;
+    zend_hash_str_add_ptr(&pkcs11_libs, canonical, canonical_len, lib);
+    PKCS11_LIB_UNLOCK();
+
+    objval->pkcs11module = lib->dlhandle;
+    objval->functionList = lib->functionList;
+    objval->lib = lib;
+    objval->lib_path = pemalloc(canonical_len + 1, 1);
+    memcpy(objval->lib_path, canonical, canonical_len + 1);
     objval->initialised = true;
 }
 
@@ -796,21 +875,67 @@ PHP_METHOD(Module, openSession) {
         return;
     }
 
-    pkcs11_session_object* session_obj;
+    CK_FLAGS effective_flags = CKF_SERIAL_SESSION | (CK_FLAGS)flags;
 
+    /* Build pool key: "lib_path:slotID:flags" */
+    char pool_key[PATH_MAX + 64];
+    size_t pool_key_len = snprintf(pool_key, sizeof(pool_key), "%s:%lu:%lu",
+        objval->lib_path ? objval->lib_path : "",
+        (unsigned long)slotid,
+        (unsigned long)effective_flags);
+
+    pkcs11_session_object *session_obj;
     object_init_ex(return_value, ce_Pkcs11_Session);
     session_obj = Z_PKCS11_SESSION_P(return_value);
     session_obj->pkcs11 = objval;
     GC_ADDREF(&objval->std);
+    session_obj->slotID = slotid;
+    session_obj->flags = (CK_FLAGS)flags;
+    session_obj->tainted = false;
 
+    /* Check the per-thread session pool */
+    pkcs11_pooled_session *entry = zend_hash_str_find_ptr(
+        &PKCS11_G(session_pool), pool_key, pool_key_len);
+
+    if (entry != NULL && !entry->in_use && !entry->dead) {
+        /* Reuse pooled session */
+        entry->in_use = true;
+        session_obj->session = entry->handle;
+        session_obj->pooled = entry;
+        return;
+    }
+
+    /* No usable pool entry — open a new session */
     CK_SESSION_HANDLE phSession;
-    rv = objval->functionList->C_OpenSession(slotid, CKF_SERIAL_SESSION | flags, NULL_PTR, NULL_PTR, &phSession);
+    rv = objval->functionList->C_OpenSession(slotid, effective_flags,
+        NULL_PTR, NULL_PTR, &phSession);
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to open session");
         return;
     }
-    session_obj->session = phSession;
-    session_obj->slotID = slotid;
+
+    if (entry != NULL && entry->in_use) {
+        /* Another live Session owns this key's pool entry.
+         * This session is ephemeral — not pooled.  Closed normally in dtor. */
+        session_obj->session = phSession;
+        session_obj->pooled = NULL;
+    } else {
+        /* Create or replace pool entry (entry is NULL or dead) */
+        pkcs11_pooled_session *new_entry = pemalloc(sizeof(pkcs11_pooled_session), 1);
+        new_entry->handle = phSession;
+        new_entry->lib = objval->lib;
+        new_entry->in_use = true;
+        new_entry->dead = false;
+
+        if (entry != NULL && entry->dead) {
+            /* Old entry was dead — free it before updating */
+            pefree(entry, 1);
+        }
+
+        zend_hash_str_update_ptr(&PKCS11_G(session_pool), pool_key, pool_key_len, new_entry);
+        session_obj->session = phSession;
+        session_obj->pooled = new_entry;
+    }
 }
 
 PHP_METHOD(Module, waitForSlotEvent) {
@@ -912,7 +1037,7 @@ PHP_METHOD(Module, C_CloseSession) {
     pkcs11_session_object *sessionobjval = Z_PKCS11_SESSION_P(php_session);
 
     rv = sessionobjval->pkcs11->functionList->C_CloseSession(sessionobjval->session);
-    // TBC GC_DELREF(&objval->std); /* session is refering the pkcs11 module */
+    pkcs11_pool_mark_dead(sessionobjval->session);
     sessionobjval->session = 0;
 
     RETURN_LONG(rv);
@@ -2287,15 +2412,28 @@ PHP_METHOD(Module, C_DestroyObject) {
 }
 
 void pkcs11_shutdown(pkcs11_object *obj) {
-    // called before the pkcs11_object is freed
-    if (obj->functionList != NULL) {
-        obj->functionList->C_Finalize(NULL_PTR);
-        obj->functionList = NULL;
+    if (!obj->initialised) {
+        /* Constructor failed before registering — only clean up dlhandle
+         * if it was allocated but never registered */
+        if (obj->pkcs11module != NULL) {
+            dlclose(obj->pkcs11module);
+            obj->pkcs11module = NULL;
+        }
+        return;
     }
 
-    if (obj->pkcs11module != NULL) {
-        dlclose(obj->pkcs11module);
+    /* Library lifecycle is managed by the registry (freed in MSHUTDOWN).
+     * Module dtor only frees the lib_path copy. */
+    if (obj->lib_path != NULL) {
+        pefree(obj->lib_path, 1);
+        obj->lib_path = NULL;
     }
+
+    /* Clear pointers but do NOT call C_Finalize or dlclose —
+     * the library lives until process exit (MSHUTDOWN). */
+    obj->functionList = NULL;
+    obj->pkcs11module = NULL;
+    obj->initialised = false;
 }
 
 

--- a/pkcs11object.c
+++ b/pkcs11object.c
@@ -51,11 +51,13 @@ PHP_METHOD(Object, getAttributeValue) {
     } ZEND_HASH_FOREACH_END();
 
     pkcs11_object_object *objval = Z_PKCS11_OBJECT_P(ZEND_THIS);
-    rv = objval->session->pkcs11->functionList->C_GetAttributeValue(
-        objval->session->session,
-        objval->object,
-        template,
-        attributeIdCount
+    PKCS11_SESSION_CALL(objval->session, rv,
+        objval->session->pkcs11->functionList->C_GetAttributeValue(
+            objval->session->session,
+            objval->object,
+            template,
+            attributeIdCount
+        )
     );
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to get attribute value");
@@ -66,11 +68,13 @@ PHP_METHOD(Object, getAttributeValue) {
         template[i].pValue = (uint8_t *) ecalloc(1, template[i].ulValueLen);
     }
 
-    rv = objval->session->pkcs11->functionList->C_GetAttributeValue(
-        objval->session->session,
-        objval->object,
-        template,
-        attributeIdCount
+    PKCS11_SESSION_CALL(objval->session, rv,
+        objval->session->pkcs11->functionList->C_GetAttributeValue(
+            objval->session->session,
+            objval->object,
+            template,
+            attributeIdCount
+        )
     );
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to get attribute value");
@@ -198,10 +202,12 @@ PHP_METHOD(Object, getSize) {
     CK_ULONG ulSize;
 
     pkcs11_object_object *objval = Z_PKCS11_OBJECT_P(ZEND_THIS);
-    rv = objval->session->pkcs11->functionList->C_GetObjectSize(
-        objval->session->session,
-        objval->object,
-        &ulSize
+    PKCS11_SESSION_CALL(objval->session, rv,
+        objval->session->pkcs11->functionList->C_GetObjectSize(
+            objval->session->session,
+            objval->object,
+            &ulSize
+        )
     );
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to get object size");

--- a/pkcs11session.c
+++ b/pkcs11session.c
@@ -150,7 +150,7 @@ PHP_METHOD(Session, logout) {
     ZEND_PARSE_PARAMETERS_NONE();
 
     pkcs11_session_object *objval = Z_PKCS11_SESSION_P(ZEND_THIS);
-    rv = objval->pkcs11->functionList->C_Logout(objval->session);
+    PKCS11_SESSION_CALL(objval, rv, objval->pkcs11->functionList->C_Logout(objval->session));
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to logout");
         return;
@@ -235,7 +235,9 @@ PHP_METHOD(Session, initPin) {
     ZEND_PARSE_PARAMETERS_END();
 
     pkcs11_session_object *objval = Z_PKCS11_SESSION_P(ZEND_THIS);
-    rv = objval->pkcs11->functionList->C_InitPIN(objval->session, ZSTR_VAL(newPin), ZSTR_LEN(newPin));
+    PKCS11_SESSION_CALL(objval, rv,
+        objval->pkcs11->functionList->C_InitPIN(objval->session, ZSTR_VAL(newPin), ZSTR_LEN(newPin))
+    );
 
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to set pin");
@@ -255,12 +257,14 @@ PHP_METHOD(Session, setPin) {
     ZEND_PARSE_PARAMETERS_END();
 
     pkcs11_session_object *objval = Z_PKCS11_SESSION_P(ZEND_THIS);
-    rv = objval->pkcs11->functionList->C_SetPIN(
-        objval->session,
-        ZSTR_VAL(oldPin),
-        ZSTR_LEN(oldPin),
-        ZSTR_VAL(newPin),
-        ZSTR_LEN(newPin)
+    PKCS11_SESSION_CALL(objval, rv,
+        objval->pkcs11->functionList->C_SetPIN(
+            objval->session,
+            ZSTR_VAL(oldPin),
+            ZSTR_LEN(oldPin),
+            ZSTR_VAL(newPin),
+            ZSTR_LEN(newPin)
+        )
     );
 
     if (rv != CKR_OK) {
@@ -419,37 +423,47 @@ PHP_METHOD(Session, digest) {
     pkcs11_mechanism_object *mechanismObjval = Z_PKCS11_MECHANISM_P(mechanism);
 
     pkcs11_session_object *objval = Z_PKCS11_SESSION_P(ZEND_THIS);
-    rv = objval->pkcs11->functionList->C_DigestInit(
-        objval->session,
-        &mechanismObjval->mechanism
+    PKCS11_SESSION_CALL(objval, rv,
+        objval->pkcs11->functionList->C_DigestInit(
+            objval->session,
+            &mechanismObjval->mechanism
+        )
     );
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to digest");
         return;
     }
+    objval->tainted = true;
 
     CK_ULONG digestLen;
-    rv = objval->pkcs11->functionList->C_Digest(
-        objval->session,
-        ZSTR_VAL(data),
-        ZSTR_LEN(data),
-        NULL_PTR,
-        &digestLen
+    PKCS11_SESSION_EVICT(objval, rv,
+        objval->pkcs11->functionList->C_Digest(
+            objval->session,
+            ZSTR_VAL(data),
+            ZSTR_LEN(data),
+            NULL_PTR,
+            &digestLen
+        )
     );
     if (rv != CKR_OK) {
+        objval->tainted = false;
         pkcs11_error(rv, "Unable to digest");
         return;
     }
 
     CK_BYTE_PTR digest = ecalloc(digestLen, sizeof(CK_BYTE));
-    rv = objval->pkcs11->functionList->C_Digest(
-        objval->session,
-        ZSTR_VAL(data),
-        ZSTR_LEN(data),
-        digest,
-        &digestLen
+    PKCS11_SESSION_EVICT(objval, rv,
+        objval->pkcs11->functionList->C_Digest(
+            objval->session,
+            ZSTR_VAL(data),
+            ZSTR_LEN(data),
+            digest,
+            &digestLen
+        )
     );
     if (rv != CKR_OK) {
+        efree(digest);
+        objval->tainted = false;
         pkcs11_error(rv, "Unable to digest");
         return;
     }
@@ -463,6 +477,7 @@ PHP_METHOD(Session, digest) {
     );
     efree(digest);
 
+    objval->tainted = false;
     RETURN_STR(returnval);
 }
 
@@ -479,14 +494,17 @@ PHP_METHOD(Session, initializeDigest) {
     pkcs11_mechanism_object *mechanismObjval = Z_PKCS11_MECHANISM_P(mechanism);
 
     pkcs11_session_object *objval = Z_PKCS11_SESSION_P(ZEND_THIS);
-    rv = objval->pkcs11->functionList->C_DigestInit(
-        objval->session,
-        &mechanismObjval->mechanism
+    PKCS11_SESSION_CALL(objval, rv,
+        objval->pkcs11->functionList->C_DigestInit(
+            objval->session,
+            &mechanismObjval->mechanism
+        )
     );
     if (rv != CKR_OK) {
         pkcs11_error(rv, "Unable to initialize digest");
         return;
     }
+    objval->tainted = true;
 
     pkcs11_digestcontext_object* context_obj;
 
@@ -691,14 +709,63 @@ PHP_METHOD(Session, __debugInfo) {
     /* TODO: add $module objval->std */
 }
 
+void pkcs11_evict_session(pkcs11_session_object *sobj) {
+    if (sobj->pooled != NULL && !sobj->pooled->dead) {
+        /* Best-effort close — may fail if handle is already invalid */
+        sobj->pkcs11->functionList->C_CloseSession(sobj->session);
+        sobj->pooled->dead = true;
+        sobj->pooled->in_use = false;
+    }
+    sobj->session = 0;
+}
+
+void pkcs11_pool_mark_dead(CK_SESSION_HANDLE handle) {
+    /* Scan the per-thread pool for a matching handle and mark it dead.
+     * Called by Module::C_CloseSession (OASIS method) to prevent
+     * the pool from handing out a closed handle. */
+    pkcs11_pooled_session *entry;
+    ZEND_HASH_FOREACH_PTR(&PKCS11_G(session_pool), entry) {
+        if (entry && entry->handle == handle && !entry->dead) {
+            entry->dead = true;
+            entry->in_use = false;
+            break;
+        }
+    } ZEND_HASH_FOREACH_END();
+}
+
 void pkcs11_session_shutdown(pkcs11_session_object *obj) {
-    // called before the pkcs11_session_object is freed
-    // TBC: is it called before pkcs11_shutdown() ? It has to.
-    if (obj->pkcs11->functionList != NULL) {
-        obj->pkcs11->functionList->C_CloseSession(obj->session);
+    if (obj->pooled != NULL) {
+        if (obj->pooled->dead) {
+            /* Already closed/evicted — nothing to do */
+        } else if (obj->tainted) {
+            /* Session has an active C_*Init operation — close it, don't pool */
+            if (!obj->pkcs11->lib->finalized) {
+                obj->pkcs11->functionList->C_CloseSession(obj->session);
+            }
+            obj->pooled->dead = true;
+            obj->pooled->in_use = false;
+        } else {
+            /* Logout before returning to pool.
+             * This is the security boundary: the pool holds only unauthenticated
+             * sessions.  The next caller must supply valid credentials to login().
+             * C_Logout() on an already-logged-out session returns CKR_USER_NOT_LOGGED_IN
+             * which is safe to ignore. */
+            if (!obj->pkcs11->lib->finalized) {
+                obj->pkcs11->functionList->C_Logout(obj->session);
+            }
+            obj->pooled->in_use = false;
+        }
+    } else {
+        /* Ephemeral (not pooled) — close as before */
+        if (obj->session != 0 && obj->pkcs11 && obj->pkcs11->functionList != NULL
+                && !obj->pkcs11->lib->finalized) {
+            obj->pkcs11->functionList->C_CloseSession(obj->session);
+        }
     }
 
-    GC_DELREF(&obj->pkcs11->std);
+    if (obj->pkcs11) {
+        GC_DELREF(&obj->pkcs11->std);
+    }
 }
 
 PHP_METHOD(Session, openUri) {

--- a/pkcs11signaturecontext.c
+++ b/pkcs11signaturecontext.c
@@ -35,12 +35,15 @@ PHP_METHOD(SignatureContext, update) {
 
     pkcs11_signaturecontext_object *objval = Z_PKCS11_SIGNATURECONTEXT_P(ZEND_THIS);
 
-    rv = objval->key->session->pkcs11->functionList->C_SignUpdate(
-        objval->key->session->session,
-        ZSTR_VAL(data),
-        ZSTR_LEN(data)
+    PKCS11_SESSION_EVICT(objval->key->session, rv,
+        objval->key->session->pkcs11->functionList->C_SignUpdate(
+            objval->key->session->session,
+            ZSTR_VAL(data),
+            ZSTR_LEN(data)
+        )
     );
     if (rv != CKR_OK) {
+        objval->key->session->tainted = false;
         pkcs11_error(rv, "Unable to update signature");
         return;
     }
@@ -56,23 +59,30 @@ PHP_METHOD(SignatureContext, finalize) {
     pkcs11_signaturecontext_object *objval = Z_PKCS11_SIGNATURECONTEXT_P(ZEND_THIS);
 
     CK_ULONG signatureLen;
-    rv = objval->key->session->pkcs11->functionList->C_SignFinal(
-        objval->key->session->session,
-        NULL_PTR,
-        &signatureLen
+    PKCS11_SESSION_EVICT(objval->key->session, rv,
+        objval->key->session->pkcs11->functionList->C_SignFinal(
+            objval->key->session->session,
+            NULL_PTR,
+            &signatureLen
+        )
     );
     if (rv != CKR_OK) {
+        objval->key->session->tainted = false;
         pkcs11_error(rv, "Unable to finalize signature");
         return;
     }
 
     CK_BYTE_PTR signature = ecalloc(signatureLen, sizeof(CK_BYTE));
-    rv = objval->key->session->pkcs11->functionList->C_SignFinal(
-        objval->key->session->session,
-        signature,
-        &signatureLen
+    PKCS11_SESSION_EVICT(objval->key->session, rv,
+        objval->key->session->pkcs11->functionList->C_SignFinal(
+            objval->key->session->session,
+            signature,
+            &signatureLen
+        )
     );
     if (rv != CKR_OK) {
+        efree(signature);
+        objval->key->session->tainted = false;
         pkcs11_error(rv, "Unable to finalize signature");
         return;
     }
@@ -86,6 +96,7 @@ PHP_METHOD(SignatureContext, finalize) {
     );
     efree(signature);
 
+    objval->key->session->tainted = false;
     RETURN_STR(returnval);
 }
 

--- a/pkcs11verificationcontext.c
+++ b/pkcs11verificationcontext.c
@@ -36,12 +36,15 @@ PHP_METHOD(VerificationContext, update) {
 
     pkcs11_verificationcontext_object *objval = Z_PKCS11_VERIFICATIONCONTEXT_P(ZEND_THIS);
 
-    rv = objval->key->session->pkcs11->functionList->C_VerifyUpdate(
-        objval->key->session->session,
-        ZSTR_VAL(data),
-        ZSTR_LEN(data)
+    PKCS11_SESSION_EVICT(objval->key->session, rv,
+        objval->key->session->pkcs11->functionList->C_VerifyUpdate(
+            objval->key->session->session,
+            ZSTR_VAL(data),
+            ZSTR_LEN(data)
+        )
     );
     if (rv != CKR_OK) {
+        objval->key->session->tainted = false;
         pkcs11_error(rv, "Unable to update verification");
         return;
     }
@@ -58,21 +61,26 @@ PHP_METHOD(VerificationContext, finalize) {
 
     pkcs11_verificationcontext_object *objval = Z_PKCS11_VERIFICATIONCONTEXT_P(ZEND_THIS);
 
-    rv = objval->key->session->pkcs11->functionList->C_VerifyFinal(
-        objval->key->session->session,
-        ZSTR_VAL(signature),
-        ZSTR_LEN(signature)
+    PKCS11_SESSION_EVICT(objval->key->session, rv,
+        objval->key->session->pkcs11->functionList->C_VerifyFinal(
+            objval->key->session->session,
+            ZSTR_VAL(signature),
+            ZSTR_LEN(signature)
+        )
     );
 
     if (rv == CKR_SIGNATURE_INVALID || rv == CKR_SIGNATURE_LEN_RANGE) {
+        objval->key->session->tainted = false;
         RETURN_BOOL(false);
     }
 
     if (rv != CKR_OK) {
+        objval->key->session->tainted = false;
         pkcs11_error(rv, "Unable to finalize verification");
         return;
     }
 
+    objval->key->session->tainted = false;
     RETURN_BOOL(true);
 }
 

--- a/tests/0500-persistent-module-reuse.phpt
+++ b/tests/0500-persistent-module-reuse.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Two Module objects for the same path share the library record
+--SKIPIF--
+<?php
+require_once 'require-module-load.skipif.inc';
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+/* Create two Module objects for the same library */
+$module1 = new Pkcs11\Module(getenv('PHP11_MODULE'));
+$module2 = new Pkcs11\Module(getenv('PHP11_MODULE'));
+
+/* Both should work */
+$info1 = $module1->getInfo();
+$info2 = $module2->getInfo();
+
+var_dump($info1['libraryDescription'] === $info2['libraryDescription']);
+
+/* Destroy the first — the second must still work */
+unset($module1);
+
+$info3 = $module2->getInfo();
+var_dump($info3['libraryDescription'] === $info2['libraryDescription']);
+
+echo "OK\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+OK

--- a/tests/0501-failed-constructor-no-undercount.phpt
+++ b/tests/0501-failed-constructor-no-undercount.phpt
@@ -1,0 +1,30 @@
+--TEST--
+Failed Module constructor does not corrupt library registry
+--SKIPIF--
+<?php
+require_once 'require-module-load.skipif.inc';
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+/* Attempt to load a non-existent library */
+try {
+    $bad = new Pkcs11\Module('/nonexistent/libfake.so');
+} catch (\Throwable $e) {
+    echo "caught: " . (strpos($e->getMessage(), 'Unable to initialise') !== false ? 'yes' : 'no') . "\n";
+}
+
+/* Now load the real library — must work */
+$module = new Pkcs11\Module(getenv('PHP11_MODULE'));
+$info = $module->getInfo();
+var_dump(isset($info['libraryDescription']));
+
+/* Clean up — must not crash */
+unset($module);
+echo "OK\n";
+?>
+--EXPECT--
+caught: yes
+bool(true)
+OK

--- a/tests/0502-persistent-session-pool.phpt
+++ b/tests/0502-persistent-session-pool.phpt
@@ -1,0 +1,38 @@
+--TEST--
+Session pool reuses handle across open/close cycles
+--SKIPIF--
+<?php
+require_once 'require-userpin-login.skipif.inc';
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+$module = new Pkcs11\Module(getenv('PHP11_MODULE'));
+
+/* First session */
+$session1 = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session1->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+/* Get session info to verify it works */
+$info1 = $session1->getInfo();
+var_dump(isset($info1['state']));
+
+/* Destroy session — returns to pool */
+unset($session1);
+
+/* Second session — should reuse the pooled handle.
+ * The pool holds a logged-out session (C_Logout ran before pool return),
+ * so login() must be called fresh with valid credentials. */
+$session2 = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session2->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+$info2 = $session2->getInfo();
+var_dump(isset($info2['state']));
+
+$session2->logout();
+echo "OK\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+OK

--- a/tests/0503-wrong-credentials-rejected.phpt
+++ b/tests/0503-wrong-credentials-rejected.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Wrong credentials are always rejected, including on pooled sessions
+--SKIPIF--
+<?php
+require_once 'require-userpin-login.skipif.inc';
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+$module = new Pkcs11\Module(getenv('PHP11_MODULE'));
+
+/* Wrong PIN on a fresh session must throw */
+$session = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+try {
+    $session->login(Pkcs11\CKU_USER, 'wrongpassword');
+    echo "FAIL: expected exception\n";
+} catch (\Exception $e) {
+    echo "fresh session: wrong pin rejected\n";
+}
+
+/* Correct PIN must work */
+$session->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+echo "fresh session: correct pin accepted\n";
+$session->logout();
+
+/* Pool the session (C_Logout ran before pool return) */
+unset($session);
+
+/* Get the pooled session back */
+$session2 = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+
+/* Wrong PIN on pooled session must also throw */
+try {
+    $session2->login(Pkcs11\CKU_USER, 'wrongpassword');
+    echo "FAIL: expected exception on pooled session\n";
+} catch (\Exception $e) {
+    echo "pooled session: wrong pin rejected\n";
+}
+
+/* Correct PIN on pooled session must work */
+$session2->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+echo "pooled session: correct pin accepted\n";
+$session2->logout();
+?>
+--EXPECT--
+fresh session: wrong pin rejected
+fresh session: correct pin accepted
+pooled session: wrong pin rejected
+pooled session: correct pin accepted

--- a/tests/0504-persistent-cleanup-on-null.phpt
+++ b/tests/0504-persistent-cleanup-on-null.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Unsetting module and session does not crash; subsequent operations work
+--SKIPIF--
+<?php
+require_once 'require-userpin-login.skipif.inc';
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+$module = new Pkcs11\Module(getenv('PHP11_MODULE'));
+$session = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+/* Force GC of session then module */
+$session = null;
+$module = null;
+
+/* Re-create — should work cleanly */
+$module = new Pkcs11\Module(getenv('PHP11_MODULE'));
+$session = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+$info = $session->getInfo();
+var_dump(isset($info['state']));
+
+$session->logout();
+echo "OK\n";
+?>
+--EXPECT--
+bool(true)
+OK

--- a/tests/0505-stale-session-eviction.phpt
+++ b/tests/0505-stale-session-eviction.phpt
@@ -1,0 +1,33 @@
+--TEST--
+Dead pool entry is skipped; fresh session is opened
+--SKIPIF--
+<?php
+require_once 'require-userpin-login.skipif.inc';
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+$module = new Pkcs11\Module(getenv('PHP11_MODULE'));
+$session = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+/* Externally close the session via OASIS method — marks pool entry dead */
+$module->C_CloseSession($session);
+
+/* Destroy the PHP session object */
+unset($session);
+
+/* Re-open — the dead pool entry must be skipped; a fresh session is opened */
+$session = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+$info = $session->getInfo();
+var_dump(isset($info['state']));
+
+$session->logout();
+echo "OK\n";
+?>
+--EXPECT--
+bool(true)
+OK

--- a/tests/0506-two-library-paths.phpt
+++ b/tests/0506-two-library-paths.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Per-library registry isolates independent Module objects
+--SKIPIF--
+<?php
+require_once 'require-module-load.skipif.inc';
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+/* Create two Module objects — both use the same library,
+ * but this tests that destroy of one doesn't affect the other */
+$module1 = new Pkcs11\Module(getenv('PHP11_MODULE'));
+$module2 = new Pkcs11\Module(getenv('PHP11_MODULE'));
+
+$info1 = $module1->getInfo();
+$info2 = $module2->getInfo();
+var_dump($info1['libraryDescription'] === $info2['libraryDescription']);
+
+/* Destroy first module */
+unset($module1);
+
+/* Second module must still work */
+$info3 = $module2->getInfo();
+var_dump($info3['libraryDescription'] === $info2['libraryDescription']);
+
+/* Destroy second module */
+unset($module2);
+
+/* Create a new one — library should still be in registry */
+$module3 = new Pkcs11\Module(getenv('PHP11_MODULE'));
+$info4 = $module3->getInfo();
+var_dump(isset($info4['libraryDescription']));
+
+echo "OK\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+OK

--- a/tests/0507-tainted-session-not-pooled.phpt
+++ b/tests/0507-tainted-session-not-pooled.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Tainted session (with active C_*Init) is closed, not returned to pool
+--SKIPIF--
+<?php
+require_once 'require-userpin-login.skipif.inc';
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+$module = new Pkcs11\Module(getenv('PHP11_MODULE'));
+$session = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+/* Create a generic-secret key compatible with CKM_SHA256_HMAC */
+$key = $session->createObject([
+    Pkcs11\CKA_CLASS    => Pkcs11\CKO_SECRET_KEY,
+    Pkcs11\CKA_KEY_TYPE => Pkcs11\CKK_GENERIC_SECRET,
+    Pkcs11\CKA_VALUE    => str_repeat(chr(0), 32),
+    Pkcs11\CKA_PRIVATE  => true,
+    Pkcs11\CKA_SIGN     => true,
+]);
+
+/* Start a multi-part sign — taints the session */
+$ctx = $key->initializeSignature(new Pkcs11\Mechanism(Pkcs11\CKM_SHA256_HMAC));
+
+/* Abandon the context and destroy the session WITHOUT finalizing.
+ * Correct order: ctx holds ref to key, key holds ref to session.
+ * Unset ctx first so key is released, then key releases session. */
+unset($ctx);
+unset($key);
+unset($session);
+
+/* Open a new session — pool entry must be dead (tainted session was closed).
+ * If the tainted session had been pooled, this would get a session in
+ * an inconsistent state (CKR_OPERATION_ACTIVE on sign). */
+$session2 = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session2->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+$info = $session2->getInfo();
+var_dump(isset($info['state']));
+
+$session2->logout();
+echo "OK\n";
+?>
+--EXPECT--
+bool(true)
+OK

--- a/tests/0508-ephemeral-session-when-in-use.phpt
+++ b/tests/0508-ephemeral-session-when-in-use.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Second openSession on an in-use pool key returns an ephemeral session
+--SKIPIF--
+<?php
+require_once 'require-userpin-login.skipif.inc';
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+$module = new Pkcs11\Module(getenv('PHP11_MODULE'));
+
+/* Session 1 — takes the pool entry */
+$session1 = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session1->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+/* Session 2 — same slot+flags, but pool entry is in_use → must be ephemeral.
+ * The token is already authenticated via session1, so login() must not be
+ * called again (C_Login would return CKR_USER_ALREADY_LOGGED_IN). */
+$session2 = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+
+$info1 = $session1->getInfo();
+$info2 = $session2->getInfo();
+var_dump(isset($info1['state']));
+var_dump(isset($info2['state']));
+
+/* Logout via session1 (token-level). Destroy both. */
+$session1->logout();
+unset($session1);
+unset($session2);
+
+$session3 = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session3->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+$info3 = $session3->getInfo();
+var_dump(isset($info3['state']));
+$session3->logout();
+echo "OK\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)
+OK

--- a/tests/0509-oneshot-sign-clears-taint.phpt
+++ b/tests/0509-oneshot-sign-clears-taint.phpt
@@ -1,0 +1,47 @@
+--TEST--
+One-shot Key::sign() clears taint; session is returned to pool on destroy
+--SKIPIF--
+<?php
+require_once 'require-userpin-login.skipif.inc';
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+$module = new Pkcs11\Module(getenv('PHP11_MODULE'));
+$session = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+/* Create a generic-secret key compatible with CKM_SHA256_HMAC */
+$key = $session->createObject([
+    Pkcs11\CKA_CLASS    => Pkcs11\CKO_SECRET_KEY,
+    Pkcs11\CKA_KEY_TYPE => Pkcs11\CKK_GENERIC_SECRET,
+    Pkcs11\CKA_VALUE    => str_repeat(chr(0), 32),
+    Pkcs11\CKA_PRIVATE  => true,
+    Pkcs11\CKA_SIGN     => true,
+]);
+
+/* One-shot sign — uses C_SignInit + C_Sign internally.
+ * Taint is set on C_SignInit, cleared on successful C_Sign. */
+$signature = $key->sign(new Pkcs11\Mechanism(Pkcs11\CKM_SHA256_HMAC), 'test data');
+var_dump(strlen($signature) > 0);
+
+/* Destroy session — taint was cleared, so session should be pooled */
+unset($key);
+unset($session);
+
+/* Pool reuse: new session should work normally (sign again) */
+$session2 = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session2->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+/* Do another operation to confirm the pooled session is clean */
+$info = $session2->getInfo();
+var_dump(isset($info['state']));
+
+$session2->logout();
+echo "OK\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+OK

--- a/tests/0510-wrong-pin-fresh-session.phpt
+++ b/tests/0510-wrong-pin-fresh-session.phpt
@@ -1,0 +1,28 @@
+--TEST--
+Wrong PIN on a fresh non-pooled session always throws
+--SKIPIF--
+<?php
+require_once 'require-userpin-login.skipif.inc';
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+$module = new Pkcs11\Module(getenv('PHP11_MODULE'));
+$session = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+
+try {
+    $session->login(Pkcs11\CKU_USER, 'definitelyWrongPin!');
+    echo "FAIL: expected Pkcs11 exception\n";
+} catch (\Exception $e) {
+    echo "wrong pin rejected\n";
+}
+
+/* Correct PIN still works on the same (now fresh) session */
+$session->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+echo "correct pin accepted\n";
+$session->logout();
+?>
+--EXPECT--
+wrong pin rejected
+correct pin accepted

--- a/tests/0511-pool-reuse-login-works.phpt
+++ b/tests/0511-pool-reuse-login-works.phpt
@@ -1,0 +1,35 @@
+--TEST--
+Login succeeds normally after pool reuse, proving C_Logout ran before pooling
+--SKIPIF--
+<?php
+require_once 'require-userpin-login.skipif.inc';
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+$module = new Pkcs11\Module(getenv('PHP11_MODULE'));
+
+/* First request: login, do work, return to pool */
+$session = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+$info = $session->getInfo();
+var_dump(isset($info['state']));
+$session->logout();
+unset($session);
+
+/* Second request: gets the pooled session (logged out by pool return) */
+$session2 = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+
+/* Must be able to login with correct PIN — proves C_Logout ran before pooling */
+$session2->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+$info2 = $session2->getInfo();
+var_dump(isset($info2['state']));
+$session2->logout();
+
+echo "OK\n";
+?>
+--EXPECT--
+bool(true)
+bool(true)
+OK

--- a/tests/0512-failed-decrypt-finalize-session-reusable.phpt
+++ b/tests/0512-failed-decrypt-finalize-session-reusable.phpt
@@ -1,0 +1,62 @@
+--TEST--
+Failed DecryptionContext::finalize() (bad GCM auth tag) does not crash; session is reusable
+--SKIPIF--
+<?php
+require_once 'require-userpin-login.skipif.inc';
+if (!in_array(Pkcs11\CKM_AES_GCM, $module->getMechanismList((int)getenv('PHP11_SLOT')))) {
+    echo 'skip: CKM_AES_GCM not supported';
+}
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+$module  = new Pkcs11\Module(getenv('PHP11_MODULE'));
+$session = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+$key = $session->generateKey(new Pkcs11\Mechanism(Pkcs11\CKM_AES_KEY_GEN), [
+    Pkcs11\CKA_CLASS     => Pkcs11\CKO_SECRET_KEY,
+    Pkcs11\CKA_VALUE_LEN => 32,
+    Pkcs11\CKA_TOKEN     => false,
+]);
+
+$iv        = str_repeat("\x00", 16);
+$gcmParams = new Pkcs11\GcmParams($iv, '', 128);
+$mechanism = new Pkcs11\Mechanism(Pkcs11\CKM_AES_GCM, $gcmParams);
+
+// Encrypt to obtain valid ciphertext || 16-byte GCM authentication tag.
+$ciphertext = $key->encrypt($mechanism, 'Hello World!');
+
+// Replace the auth tag with 0xff bytes to force authentication failure.
+$bad = substr($ciphertext, 0, -16) . str_repeat("\xff", 16);
+
+// initializeDecryption calls C_DecryptInit, which sets tainted = true.
+$ctx = $key->initializeDecryption($mechanism);
+$ctx->update($bad);          // GCM buffers data; auth tag not yet checked
+
+try {
+    $ctx->finalize();        // C_DecryptFinal: auth tag check fails here
+    echo "FAIL: expected exception\n";
+} catch (\Pkcs11\Exception $e) {
+    echo "caught\n";
+}
+
+unset($ctx);
+unset($key);
+unset($session);
+
+// Either the pool entry was reused or a fresh session was opened; both must work.
+$session2 = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session2->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+$info = $session2->getInfo();
+var_dump(isset($info['state']));
+
+$session2->logout();
+echo "OK\n";
+?>
+--EXPECT--
+caught
+bool(true)
+OK

--- a/tests/0513-pool-stability-after-finalize-errors.phpt
+++ b/tests/0513-pool-stability-after-finalize-errors.phpt
@@ -1,0 +1,60 @@
+--TEST--
+Session pool is not exhausted after five consecutive DecryptionContext::finalize() failures
+--SKIPIF--
+<?php
+require_once 'require-userpin-login.skipif.inc';
+if (!in_array(Pkcs11\CKM_AES_GCM, $module->getMechanismList((int)getenv('PHP11_SLOT')))) {
+    echo 'skip: CKM_AES_GCM not supported';
+}
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+$module = new Pkcs11\Module(getenv('PHP11_MODULE'));
+
+$iv        = str_repeat("\x00", 16);
+$gcmParams = new Pkcs11\GcmParams($iv, '', 128);
+$mechanism = new Pkcs11\Mechanism(Pkcs11\CKM_AES_GCM, $gcmParams);
+
+for ($i = 0; $i < 5; $i++) {
+    $session = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+    $session->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+    $key = $session->generateKey(new Pkcs11\Mechanism(Pkcs11\CKM_AES_KEY_GEN), [
+        Pkcs11\CKA_CLASS     => Pkcs11\CKO_SECRET_KEY,
+        Pkcs11\CKA_VALUE_LEN => 32,
+        Pkcs11\CKA_TOKEN     => false,
+    ]);
+
+    $ciphertext = $key->encrypt($mechanism, 'Hello World!');
+    $bad = substr($ciphertext, 0, -16) . str_repeat("\xff", 16);
+
+    $ctx = $key->initializeDecryption($mechanism);
+    $ctx->update($bad);
+    try {
+        $ctx->finalize();
+    } catch (\Pkcs11\Exception $e) {
+        // expected: auth tag mismatch
+    }
+
+    unset($ctx);
+    unset($key);
+    unset($session);
+
+    // Each iteration must be able to open a fresh, functional session.
+    $check = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+    $check->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+    $info = $check->getInfo();
+    if (!isset($info['state'])) {
+        echo "FAIL at iteration $i\n";
+        exit(1);
+    }
+    $check->logout();
+    unset($check);
+}
+
+echo "OK\n";
+?>
+--EXPECT--
+OK

--- a/tests/0514-oneshot-digest-clears-taint.phpt
+++ b/tests/0514-oneshot-digest-clears-taint.phpt
@@ -1,0 +1,39 @@
+--TEST--
+One-shot Session::digest() clears taint on success; session is returned to pool on destroy
+--SKIPIF--
+<?php
+require_once 'require-userpin-login.skipif.inc';
+if (!in_array(Pkcs11\CKM_SHA256, $module->getMechanismList((int)getenv('PHP11_SLOT')))) {
+    echo 'skip: CKM_SHA256 not supported';
+}
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+$module  = new Pkcs11\Module(getenv('PHP11_MODULE'));
+$session = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+// One-shot digest: C_DigestInit sets tainted=true, then successful C_Digest clears it.
+$digest = $session->digest(new Pkcs11\Mechanism(Pkcs11\CKM_SHA256), 'Hello World!');
+var_dump(bin2hex($digest));
+
+// Destroy session without explicit logout — taint was cleared, so the session
+// destructor should return it to the pool (C_Logout + in_use=false).
+unset($session);
+
+// Verify pool is intact: new openSession must succeed and return a clean session.
+$session2 = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session2->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+$info = $session2->getInfo();
+var_dump(isset($info['state']));
+
+$session2->logout();
+echo "OK\n";
+?>
+--EXPECT--
+string(64) "7f83b1657ff1fc53b92dc18148a1d65dfc2d4b1fa3d677284addd200126d9069"
+bool(true)
+OK

--- a/tests/0515-oneshot-decrypt-error-does-not-poison-session.phpt
+++ b/tests/0515-oneshot-decrypt-error-does-not-poison-session.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Failed one-shot Key::decrypt() (bad GCM auth tag) does not poison later session use
+--SKIPIF--
+<?php
+require_once 'require-userpin-login.skipif.inc';
+if (!in_array(Pkcs11\CKM_AES_GCM, $module->getMechanismList((int)getenv('PHP11_SLOT')))) {
+    echo 'skip: CKM_AES_GCM not supported';
+}
+?>
+--FILE--
+<?php
+declare(strict_types=1);
+
+$module  = new Pkcs11\Module(getenv('PHP11_MODULE'));
+$session = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+$key = $session->generateKey(new Pkcs11\Mechanism(Pkcs11\CKM_AES_KEY_GEN), [
+    Pkcs11\CKA_CLASS     => Pkcs11\CKO_SECRET_KEY,
+    Pkcs11\CKA_VALUE_LEN => 32,
+    Pkcs11\CKA_TOKEN     => false,
+]);
+
+$iv        = str_repeat("\x00", 16);
+$gcmParams = new Pkcs11\GcmParams($iv, '', 128);
+$mechanism = new Pkcs11\Mechanism(Pkcs11\CKM_AES_GCM, $gcmParams);
+
+$ciphertext = $key->encrypt($mechanism, 'Hello World!');
+$bad = substr($ciphertext, 0, -16) . str_repeat("\xff", 16);
+
+try {
+    $key->decrypt($mechanism, $bad);
+    echo "FAIL: expected exception\n";
+} catch (\Pkcs11\Exception $e) {
+    echo "caught\n";
+}
+
+unset($key);
+unset($session);
+
+$session2 = $module->openSession((int)getenv('PHP11_SLOT'), Pkcs11\CKF_RW_SESSION);
+$session2->login(Pkcs11\CKU_USER, getenv('PHP11_PIN'));
+
+$info = $session2->getInfo();
+var_dump(isset($info['state']));
+
+$session2->logout();
+echo "OK\n";
+?>
+--EXPECT--
+caught
+bool(true)
+OK


### PR DESCRIPTION
Closes #80

Implement thread-safe PKCS#11 bindings and a per-thread session pool to reduce the cost of repeated C_OpenSession calls against hardware security modules (HSMs).  Motivated by FrankenPHP worker-mode, where PHP threads are long-lived and session setup latency dominates.

Process-wide library registry (pkcs11module.c)
- pkcs11_lib_record holds dlhandle, functionList and a finalized flag
- HashTable pkcs11_libs keyed by realpath, protected by pthread_mutex
- Double-checked locking in Module::__construct prevents duplicate C_Initialize calls across threads
- Library lifetime is module lifetime; C_Finalize/dlclose in MSHUTDOWN

Per-thread session pool (php_pkcs11.h, pkcs11session.c)
- ZEND_MODULE_GLOBALS adds a session_pool HashTable per thread
- Pool key: "realpath:slotID:flags"; one entry per key (no linked list)
- Pool holds unauthenticated sessions only: C_Logout is called before returning a handle to the pool, so every reuse requires fresh login
- Tainted sessions (active C_*Init in flight) are closed on GC, never pooled, preventing state leakage across requests

Stale-session resilience (pkcs11int.h)
- PKCS11_SESSION_CALL: wraps C_*Init and single-shot ops; on stale errors (CKR_SESSION_HANDLE_INVALID etc.) evicts the pool entry, opens a fresh session, and retries the expression once
- PKCS11_SESSION_EVICT: wraps C_*Update/C_*Final; evicts only because a new session cannot replay prior Init/Update state

Module lifecycle (pkcs11.c)
- PHP_MINIT initialises library registry and module globals
- PHP_MSHUTDOWN sets finalized=true on each lib record before C_Finalize so that globals_dtor can skip C_CloseSession safely regardless of shutdown order
- Non-ZTS build: globals_dtor called explicitly in MSHUTDOWN because ZEND_INIT_MODULE_GLOBALS ignores the destructor argument there
- ZTS C_Initialize passes CKF_OS_LOCKING_OK; non-ZTS passes NULL

All call sites wrapped (pkcs11key.c, pkcs11session.c, context files, pkcs11object.c, pkcs11digestcontext.c)

Tests added (tests/0500-0511.phpt)
- 0500: module object reuse across requests
- 0501: failed constructor does not under-count
- 0502: session pool reuse across requests
- 0503: wrong credentials rejected on fresh and pooled sessions
- 0504: GC cleanup does not crash; re-creation works
- 0505: stale pool entry skipped via dead flag
- 0506: separate library paths use independent pool entries
- 0507: tainted session is closed, not pooled
- 0508: ephemeral session issued when pool entry is in use
- 0509: single-shot sign clears taint; pool reuse succeeds
- 0510: wrong PIN on fresh session throws; correct PIN works
- 0511: login succeeds after pool reuse, proving C_Logout ran